### PR TITLE
feat: add initial OpenSearch GenAI Observability SDK codebase

### DIFF
--- a/.bandit
+++ b/.bandit
@@ -1,0 +1,25 @@
+[bandit]
+# Bandit configuration for OpenSearch GenAI SDK
+exclude_dirs = [
+    "tests",
+    "examples",
+    ".pytest_cache",
+    "__pycache__",
+    "build",
+    "dist"
+]
+
+# Skips to apply (B101 is assert_used which is OK in our context)
+skips = ["B101"]
+
+# Tests to run
+tests = [
+    "B102", "B103", "B104", "B105", "B106", "B107", "B108", "B109", "B110",
+    "B112", "B201", "B301", "B302", "B303", "B304", "B305", "B306", "B307",
+    "B308", "B309", "B310", "B311", "B312", "B313", "B314", "B315", "B316",
+    "B317", "B318", "B319", "B320", "B321", "B322", "B323", "B324", "B325",
+    "B401", "B402", "B403", "B404", "B405", "B406", "B407", "B408", "B409",
+    "B410", "B411", "B412", "B413", "B501", "B502", "B503", "B504", "B505",
+    "B506", "B507", "B601", "B602", "B603", "B604", "B605", "B606", "B607",
+    "B608", "B609", "B610", "B611", "B701", "B702", "B703"
+]

--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -1,0 +1,26 @@
+{
+  "extends": ["@commitlint/config-conventional"],
+  "rules": {
+    "type-enum": [
+      2,
+      "always",
+      [
+        "feat",
+        "fix",
+        "docs",
+        "style",
+        "refactor",
+        "perf",
+        "test",
+        "build",
+        "ci",
+        "chore",
+        "revert"
+      ]
+    ],
+    "subject-case": [2, "never", ["start-case", "pascal-case", "upper-case"]],
+    "subject-empty": [2, "never"],
+    "subject-full-stop": [2, "never", "."],
+    "header-max-length": [2, "always", 72]
+  }
+}

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,49 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: '[BUG] '
+labels: 'bug'
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Install with '...'
+2. Configure with '...'
+3. Run code '...'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Code Example**
+```python
+# Please provide a minimal code example that reproduces the issue
+```
+
+**Error Output**
+```
+# Please paste the full error message and stack trace
+```
+
+**Environment (please complete the following information):**
+ - OS: [e.g. Ubuntu 20.04, macOS 12.0, Windows 11]
+ - Python version: [e.g. 3.11.0]
+ - opensearch-genai-observability-sdk-py version: [e.g. 0.2.0]
+ - OpenTelemetry version: [e.g. 1.20.0]
+
+**Additional context**
+Add any other context about the problem here.
+
+**Configuration**
+```python
+# Please share your register() configuration (remove any sensitive data)
+register(
+    endpoint="...",
+    # ... other settings
+)
+```

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,33 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: '[FEATURE] '
+labels: 'enhancement'
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Use Case**
+Describe the specific use case or scenario where this feature would be helpful.
+
+**Example Usage**
+```python
+# Show how you would like to use this feature
+```
+
+**Additional context**
+Add any other context or screenshots about the feature request here.
+
+**Priority**
+- [ ] High - This is blocking my project
+- [ ] Medium - This would significantly improve my workflow
+- [ ] Low - This would be nice to have

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,28 @@
+version: 2
+updates:
+  # Python dependencies
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+    open-pull-requests-limit: 10
+    reviewers:
+      - "vamsimanohar"
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+
+  # GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+    open-pull-requests-limit: 5
+    reviewers:
+      - "vamsimanohar"
+    commit-message:
+      prefix: "ci"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,50 @@
+## Description
+
+<!-- Provide a brief description of the changes in this PR -->
+
+## Type of Change
+
+<!-- Please delete options that are not relevant -->
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Documentation update
+- [ ] Performance improvement
+- [ ] Refactoring (no functional changes)
+- [ ] Test improvement
+
+## How Has This Been Tested?
+
+<!-- Describe the tests that you ran to verify your changes -->
+
+- [ ] Unit tests pass
+- [ ] Integration tests pass
+- [ ] Manual testing performed
+
+## Checklist
+
+<!-- Please check all applicable boxes -->
+
+- [ ] My code follows the project's style guidelines
+- [ ] I have performed a self-review of my own code
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] I have made corresponding changes to the documentation
+- [ ] My changes generate no new warnings or errors
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] New and existing unit tests pass locally with my changes
+- [ ] Any dependent changes have been merged and published
+
+## Breaking Changes
+
+<!-- If this is a breaking change, please describe the impact and migration path -->
+
+## Related Issues
+
+<!-- Link any related issues using #issue_number -->
+
+Closes #(issue)
+
+## Additional Notes
+
+<!-- Any additional information, concerns, or context for reviewers -->

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,146 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    name: Test Python ${{ matrix.python-version }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -e ".[dev]"
+
+    - name: Run tests
+      run: |
+        pytest tests/ -v --tb=short --cov=opensearch_genai_observability_sdk_py --cov-report=xml
+
+    - name: Upload coverage to Codecov
+      if: matrix.python-version == '3.11'
+      uses: codecov/codecov-action@v4
+      with:
+        fail_ci_if_error: false
+
+  lint:
+    name: Lint and Format
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.11"
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install ruff mypy
+        pip install -e ".[dev]"
+
+    - name: Run ruff check
+      run: ruff check .
+
+    - name: Run ruff format check
+      run: ruff format --check .
+
+    - name: Run mypy
+      run: mypy src/opensearch_genai_observability_sdk_py --ignore-missing-imports
+
+  security:
+    name: Security Scan
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.11"
+
+    - name: Install bandit
+      run: pip install bandit
+
+    - name: Run Bandit Security Linter
+      run: bandit -r src/ -c .bandit -f json -o bandit-report.json || true
+
+    - name: Run Safety Security Check
+      run: |
+        pip install safety
+        safety check --json --output safety-report.json || true
+
+    - name: Upload security reports
+      uses: actions/upload-artifact@v4
+      with:
+        name: security-reports
+        path: |
+          safety-report.json
+          bandit-report.json
+
+  dependency-check:
+    name: Dependency Vulnerabilities
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.11"
+
+    - name: Install package
+      run: |
+        python -m pip install --upgrade pip
+        pip install -e ".[aws]"
+
+    - name: Run pip-audit
+      uses: pypa/gh-action-pip-audit@v1.0.8
+
+  build:
+    name: Build Package
+    runs-on: ubuntu-latest
+    needs: [test, lint]
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.11"
+
+    - name: Install build dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install build twine
+
+    - name: Build package
+      run: python -m build
+
+    - name: Check package
+      run: twine check dist/*
+
+    - name: Upload build artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: dist-packages
+        path: dist/

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -1,0 +1,73 @@
+name: PR Validation
+
+on:
+  pull_request:
+    branches: [ main ]
+    types: [opened, synchronize, reopened]
+
+jobs:
+  validate-pr:
+    name: Validate PR Requirements
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Validate PR Title
+      uses: amannn/action-semantic-pull-request@v5
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        types: |
+          feat
+          fix
+          docs
+          style
+          refactor
+          perf
+          test
+          build
+          ci
+          chore
+          revert
+
+    - name: Check for breaking changes
+      run: |
+        # Look for breaking changes in the PR description or commits
+        if git log --oneline origin/main..HEAD | grep -i "breaking\|BREAKING"; then
+          echo "⚠️ This PR contains breaking changes. Ensure version is bumped appropriately."
+        fi
+
+    - name: Validate file changes
+      run: |
+        # Check if setup files are modified
+        MODIFIED_FILES=$(git diff --name-only origin/main..HEAD)
+
+        if echo "$MODIFIED_FILES" | grep -q "pyproject.toml\|setup.py\|requirements"; then
+          echo "📦 Package configuration files modified - version bump may be needed"
+        fi
+
+        if echo "$MODIFIED_FILES" | grep -q "src/"; then
+          echo "🔧 Source code changes detected"
+        fi
+
+        if echo "$MODIFIED_FILES" | grep -q "tests/"; then
+          echo "✅ Test changes detected"
+        fi
+
+  conventional-commits:
+    name: Validate Conventional Commits
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Validate commit messages
+      uses: wagoid/commitlint-github-action@v6
+      with:
+        configFile: .commitlintrc.json
+        failOnWarnings: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,109 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  build:
+    name: Build and Validate
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.11"
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -e ".[dev]"
+
+    - name: Run tests
+      run: pytest tests/ -v
+
+    - name: Check version consistency
+      run: |
+        VERSION="${GITHUB_REF#refs/tags/v}"
+        PYPROJECT_VERSION=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['project']['version'])")
+        if [ "$VERSION" != "$PYPROJECT_VERSION" ]; then
+          echo "❌ Version mismatch: tag=$VERSION, pyproject.toml=$PYPROJECT_VERSION"
+          exit 1
+        fi
+        echo "✅ Version consistency check passed: $VERSION"
+
+    - name: Install build tools
+      run: |
+        python -m pip install --upgrade build twine
+
+    - name: Build package
+      run: python -m build
+
+    - name: Verify package
+      run: |
+        twine check dist/*
+        pip install dist/*.whl
+        python -c "import opensearch_genai_observability_sdk_py; print('Package imports successfully')"
+
+    - name: Get approvers from CODEOWNERS
+      id: get_approvers
+      run: |
+        echo "approvers=$(cat .github/CODEOWNERS | grep @ | tr -d '* ' | sed 's/@/,/g' | sed 's/,//1')" >> $GITHUB_OUTPUT
+
+    - name: Request release approval
+      uses: trstringer/manual-approval@v1
+      with:
+        secret: ${{ github.TOKEN }}
+        approvers: ${{ steps.get_approvers.outputs.approvers }}
+        minimum-approvals: 1
+        issue-title: "Release ${{ github.ref_name }}"
+        issue-body: |
+          Please approve or deny the release of opensearch-genai-observability-sdk-py.
+
+          **Tag**: ${{ github.ref_name }}
+          **Commit**: ${{ github.sha }}
+
+          Approve by commenting `approved` on this issue.
+          Deny by commenting `denied` on this issue.
+        exclude-workflow-initiator-as-approver: false
+
+    - name: Upload build artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: release-dists
+        path: dist/
+
+  pypi-publish:
+    name: Publish to PyPI
+    runs-on: ubuntu-latest
+    needs: build
+    permissions:
+      id-token: write
+      contents: write
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Download build artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: release-dists
+        path: dist/
+
+    - name: Publish to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+
+    - name: Create GitHub Release
+      uses: softprops/action-gh-release@v2
+      with:
+        generate_release_notes: true
+        prerelease: ${{ contains(github.ref_name, 'rc') || contains(github.ref_name, 'beta') || contains(github.ref_name, 'alpha') }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,168 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+Pipfile.lock
+
+# poetry
+poetry.lock
+
+# pdm
+.pdm.toml
+
+# PEP 582
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+.idea/
+
+# VS Code
+.vscode/
+
+# OS generated files
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+
+# Ruff
+.ruff_cache/
+
+# Security reports
+bandit-report.json
+safety-report.json
+
+# Temporary files
+*.tmp
+*.temp
+.tmp/
+.temp/
+
+# Test environments
+test_env/
+.pypi-token

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+#
+# Modifications Copyright OpenSearch Contributors. See
+# GitHub history for details.
+
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.9.0
+    hooks:
+      - id: ruff-format

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,41 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.2.0] - 2026-02-20
+
+### Changed
+- **BREAKING**: Removed automatic AWS endpoint detection from `auth="auto"`
+- Users must now explicitly specify `auth="sigv4"` for AWS SigV4 authentication
+- Updated documentation and examples to reflect the new authentication behavior
+
+### Added
+- Comprehensive GitHub Actions workflows for CI/CD
+- Security scanning with Bandit and Safety
+- Dependency vulnerability checks with pip-audit
+- Automated release workflow with PyPI publishing
+- PR validation with conventional commits
+- Dependabot configuration for dependency updates
+- Issue and PR templates for better contribution workflow
+- Proper package metadata and classifiers
+
+### Fixed
+- Improved repository structure for production readiness
+- Updated all examples to use explicit AWS authentication
+
+### Removed
+- `_is_aws_endpoint()` function (no longer needed)
+
+## [0.1.0] - 2024-XX-XX
+
+### Added
+- Initial release of opensearch-genai-observability-sdk-py
+- OTEL-native tracing with decorators (`@workflow`, `@task`, `@agent`, `@tool`)
+- Auto-instrumentation for popular LLM libraries
+- Scoring functionality with `score()` function
+- AWS SigV4 authentication support
+- HTTP and gRPC OTLP export support
+- Comprehensive examples and documentation

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,153 @@
+# Contributing to OpenSearch GenAI SDK
+
+Thank you for your interest in contributing to the OpenSearch GenAI SDK! We welcome contributions from the community.
+
+## Code of Conduct
+
+This project adheres to the OpenSearch [Code of Conduct](https://opensearch.org/codeofconduct.html). By participating, you are expected to uphold this code.
+
+## Getting Started
+
+### Prerequisites
+
+- Python 3.10 or higher
+- Git
+
+### Development Setup
+
+1. Fork the repository on GitHub
+2. Clone your fork locally:
+   ```bash
+   git clone https://github.com/your-username/genai-observability-sdk-py.git
+   cd genai-observability-sdk-py
+   ```
+
+3. Install the development dependencies:
+   ```bash
+   pip install -e ".[dev,aws]"
+   ```
+
+4. Run the tests to ensure everything is working:
+   ```bash
+   pytest tests/
+   ```
+
+## How to Contribute
+
+### Reporting Bugs
+
+Before creating bug reports, please check the existing issues to avoid duplicates. When creating a bug report, include:
+
+- A clear and descriptive title
+- Steps to reproduce the issue
+- Expected vs actual behavior
+- Your environment details (OS, Python version, package version)
+- Code examples that demonstrate the issue
+
+Use the [bug report template](.github/ISSUE_TEMPLATE/bug_report.md).
+
+### Suggesting Features
+
+Feature requests are welcome! Please use the [feature request template](.github/ISSUE_TEMPLATE/feature_request.md) and include:
+
+- A clear description of the problem or limitation
+- Your proposed solution
+- Example usage of the proposed feature
+- Alternative approaches you've considered
+
+### Pull Requests
+
+1. **Fork and Branch**: Create a feature branch from `main`
+   ```bash
+   git checkout -b feature/your-feature-name
+   ```
+
+2. **Follow Coding Standards**:
+   - Use [Conventional Commits](https://www.conventionalcommits.org/) for commit messages
+   - Follow the existing code style (enforced by Ruff)
+   - Add docstrings for public functions and classes
+   - Include type hints where appropriate
+
+3. **Write Tests**: Add or update tests for your changes
+   ```bash
+   pytest tests/ -v
+   ```
+
+4. **Run Quality Checks**:
+   ```bash
+   # Linting and formatting
+   ruff check .
+   ruff format .
+
+   # Type checking
+   mypy src/opensearch_genai_observability_sdk_py --ignore-missing-imports
+   ```
+
+5. **Update Documentation**: Update the README, docstrings, or examples as needed
+
+6. **Submit PR**: Create a pull request with:
+   - A clear title following conventional commit format
+   - Description of changes made
+   - Reference to related issues
+   - Test instructions for reviewers
+
+## Development Guidelines
+
+### Code Style
+
+- Follow [PEP 8](https://pep8.org/) style guidelines
+- Use Ruff for linting and formatting (configured in `pyproject.toml`)
+- Maximum line length: 100 characters
+- Use meaningful variable and function names
+
+### Commit Messages
+
+Follow [Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+type(scope): description
+
+[optional body]
+
+[optional footer]
+```
+
+Types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`
+
+Examples:
+- `feat: add support for gRPC metadata headers`
+- `fix: resolve SigV4 signing issue with temporary credentials`
+- `docs: update AWS authentication examples`
+
+### Testing
+
+- Write unit tests for new functionality
+- Use pytest with clear, descriptive test names
+- Mock external dependencies (AWS services, OTEL exporters)
+- Maintain or improve test coverage
+
+### Documentation
+
+- Update README.md for user-facing changes
+- Add docstrings for all public functions and classes
+- Update examples in the `examples/` directory
+- Include type hints for better IDE support
+
+## Release Process
+
+Releases are handled by maintainers:
+
+1. Update version in `pyproject.toml`
+2. Update `CHANGELOG.md`
+3. Create and push a version tag
+4. GitHub Actions automatically builds and publishes to PyPI
+
+## Getting Help
+
+- **Questions**: Open a [discussion](https://github.com/opensearch-project/genai-observability-sdk-py/discussions)
+- **Issues**: Use the [issue tracker](https://github.com/opensearch-project/genai-observability-sdk-py/issues)
+- **Security**: Report security vulnerabilities privately to security@opensearch.org
+
+## License
+
+By contributing to this project, you agree that your contributions will be licensed under the Apache 2.0 License.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,158 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (which shall not include communications that are not intended to
+      be part of the Work).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based upon (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and derivative works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control
+      systems, and issue tracking systems that are managed by, or on behalf
+      of, the Licensor for the purpose of discussing and improving the Work,
+      but excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to use, reproduce, modify, distribute, and prepare
+      Derivative Works of, and publicly perform and publicly display the
+      Work and such Derivative Works in all media and formats whether now
+      known or hereafter devised. You must give appropriate credit, provide
+      a link to the license, and indicate if changes were made. You may do
+      so in any reasonable manner, but not in any way that suggests the
+      licensor endorses you or your use.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You must retain, in the Source form of any
+      Derivative Works that You distribute, all copyright, patent,
+      trademark, and attribution notices from the Source form of the Work,
+      excluding those notices that do not pertain to any part of
+      the Derivative Works; and
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Support. When redistributing the Work or
+      Derivative Works thereof, You may choose to offer, and charge a fee
+      for, acceptance of support, warranty, indemnity, or other liability
+      obligations and/or rights consistent with this License. However, in
+      accepting such obligations, You may act only on Your own behalf and on
+      Your sole responsibility, not on behalf of any other Contributor, and
+      only if You agree to indemnify, defend, and hold each Contributor
+      harmless for any liability incurred by, or claims asserted against,
+      such Contributor by reason of your accepting any such warranty or support.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright 2024 OpenSearch Contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,11 @@
+OpenSearch GenAI SDK
+Copyright 2024 OpenSearch Contributors
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+This product includes software developed by the OpenTelemetry community
+(https://opentelemetry.io/).
+
+This product may include third-party libraries. Please see the
+THIRD-PARTY-LICENSES file for details.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,285 @@
+# OpenSearch GenAI SDK
+
+OTel-native tracing and scoring for LLM applications. Instrument your AI workflows with standard OpenTelemetry spans and submit evaluation scores — all routed to OpenSearch through a single OTLP pipeline.
+
+## Features
+
+- **One-line setup** — `register()` configures the full OTel pipeline (TracerProvider, exporter, auto-instrumentation)
+- **Decorators** — `@workflow`, `@task`, `@agent`, `@tool` wrap functions as OTel spans with [GenAI semantic convention](https://opentelemetry.io/docs/specs/semconv/gen-ai/) attributes
+- **Auto-instrumentation** — automatically discovers and activates installed instrumentor packages (OpenAI, Anthropic, Bedrock, LangChain, etc.)
+- **Scoring** — `score()` emits evaluation metrics as OTel spans at span, trace, or session level
+- **AWS SigV4** — built-in SigV4 signing for AWS-hosted OpenSearch and Data Prepper endpoints
+- **Zero lock-in** — remove a decorator and your code still works; everything is standard OTel
+
+## Requirements
+
+- **Python**: 3.10, 3.11, 3.12, or 3.13
+- **OpenTelemetry SDK**: ≥1.20.0, <2
+
+## Installation
+
+```bash
+pip install opensearch-genai-observability-sdk-py
+```
+
+The core package includes the OTel SDK and exporters. Auto-instrumentation of LLM libraries is opt-in — install only the providers you use:
+
+```bash
+# Single provider
+pip install opensearch-genai-observability-sdk-py[openai]
+pip install opensearch-genai-observability-sdk-py[anthropic]
+pip install opensearch-genai-observability-sdk-py[bedrock]
+pip install opensearch-genai-observability-sdk-py[langchain]
+
+# Multiple providers
+pip install "opensearch-genai-observability-sdk-py[openai,anthropic]"
+
+# All instrumentors at once
+pip install opensearch-genai-observability-sdk-py[otel-instrumentors]
+
+# Everything
+pip install opensearch-genai-observability-sdk-py[all]
+```
+
+**Available extras:** `openai`, `anthropic`, `bedrock`, `google`, `langchain`, `llamaindex`, `otel-instrumentors` (all instrumentors), `all`
+
+## Quick Start
+
+```python
+from opensearch_genai_observability_sdk_py import register, workflow, agent, tool, score
+
+# 1. Initialize tracing (one line)
+# Defaults to Data Prepper at http://localhost:21890/opentelemetry/v1/traces.
+# Set OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318 for an OTel Collector.
+register()
+
+# 2. Decorate your functions
+@tool("get_weather")
+def get_weather(city: str) -> dict:
+    """Fetch weather data for a city."""
+    return {"city": city, "temp": 22, "condition": "sunny"}
+
+@agent("weather_assistant")
+def assistant(query: str) -> str:
+    data = get_weather("Paris")
+    return f"{data['condition']}, {data['temp']}C"
+
+@workflow("weather_query")
+def run(query: str) -> str:
+    return assistant(query)
+
+result = run("What's the weather?")
+
+# 3. Submit scores (after workflow completes)
+score(name="relevance", value=0.95, trace_id="...", source="llm-judge")
+```
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────┐
+│                  Your Application                    │
+│                                                      │
+│  @workflow ─→ @agent ─→ @tool    score()            │
+│     │            │         │        │                │
+│     └────────────┴─────────┴────────┘                │
+│                     │                                │
+│            opensearch-genai-observability-sdk-py                    │
+├─────────────────────────────────────────────────────┤
+│  register()                                          │
+│  ┌─────────────────────────────────────────────┐    │
+│  │  TracerProvider                              │    │
+│  │  ├── Resource (service.name)                 │    │
+│  │  ├── BatchSpanProcessor                      │    │
+│  │  │   └── OTLPSpanExporter (HTTP or gRPC)     │    │
+│  │  │       └── SigV4 signing (AWS endpoints)   │    │
+│  │  └── Auto-instrumentation                    │    │
+│  │      ├── openai, anthropic, bedrock, ...     │    │
+│  │      ├── langchain, llamaindex, haystack     │    │
+│  │      └── chromadb, pinecone, qdrant, ...     │    │
+│  └─────────────────────────────────────────────┘    │
+└──────────────────────┬──────────────────────────────┘
+                       │ OTLP (HTTP/gRPC)
+                       ▼
+              ┌─────────────────┐
+              │  Data Prepper /  │
+              │  OTel Collector  │
+              └────────┬────────┘
+                       │
+                       ▼
+              ┌─────────────────┐
+              │   OpenSearch     │
+              │  ├── traces      │
+              │  └── scores      │
+              └─────────────────┘
+```
+
+## API Reference
+
+### `register()`
+
+Configures the OTel tracing pipeline. Call once at startup.
+
+```python
+register(
+    endpoint="http://my-collector:4318/v1/traces",  # or use env vars
+    service_name="my-app",
+    batch=True,            # BatchSpanProcessor (True) or Simple (False)
+    auto_instrument=True,  # discover installed instrumentor packages
+)
+```
+
+**Endpoint resolution (priority order):**
+
+1. `endpoint=` parameter — full URL, used as-is
+2. `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` env var — full URL, used as-is
+3. `OTEL_EXPORTER_OTLP_ENDPOINT` env var — base URL, `/v1/traces` appended automatically
+4. `http://localhost:21890/opentelemetry/v1/traces` — Data Prepper default
+
+**Protocol resolution (priority order):**
+
+1. `protocol=` parameter — `"http"` or `"grpc"`
+2. `OTEL_EXPORTER_OTLP_TRACES_PROTOCOL` env var
+3. `OTEL_EXPORTER_OTLP_PROTOCOL` env var
+4. Inferred from URL scheme
+
+**URL schemes:**
+
+| URL scheme | Transport |
+|---|---|
+| `http://` / `https://` | HTTP OTLP (protobuf) |
+| `grpc://` | gRPC (insecure) |
+| `grpcs://` | gRPC (TLS) |
+
+`http/json` is not supported. A `ValueError` is raised if the protocol contradicts a `grpc://` or `grpcs://` URL scheme.
+
+**Authenticated endpoints (e.g. AWS OSIS):** pass a custom exporter via `exporter=`:
+
+```python
+from opensearch_genai_observability_sdk_py.exporters import AWSSigV4OTLPExporter
+
+register(
+    exporter=AWSSigV4OTLPExporter(
+        endpoint="https://pipeline.us-east-1.osis.amazonaws.com/v1/traces",
+        service="osis",
+    )
+)
+```
+
+`AWSSigV4OTLPExporter` is HTTP-only. AWS OSIS does not expose a gRPC endpoint.
+
+### Decorators
+
+Four decorators for tracing application logic. Each creates an OTel span with `gen_ai.*` semantic convention attributes.
+
+| Decorator | Use for | Operation name | Span name format |
+|---|---|---|---|
+| `@workflow("name")` | Top-level orchestration | `invoke_agent` | `name` |
+| `@task("name")` | Units of work | `invoke_agent` | `name` |
+| `@agent("name")` | Autonomous agent logic | `invoke_agent` | `invoke_agent name` |
+| `@tool("name")` | Tool/function calls | `execute_tool` | `execute_tool name` |
+
+All decorators accept `name` (defaults to function's `__qualname__`) and `version`.
+
+**Attributes set automatically:**
+
+| Attribute | Set by |
+|---|---|
+| `gen_ai.operation.name` | All decorators |
+| `gen_ai.agent.name` / `gen_ai.tool.name` | All decorators |
+| `gen_ai.input.messages` / `gen_ai.output.messages` | `@workflow`, `@task`, `@agent` |
+| `gen_ai.tool.call.arguments` / `gen_ai.tool.call.result` | `@tool` |
+| `gen_ai.tool.type` | `@tool` (always `"function"`) |
+| `gen_ai.tool.description` | `@tool` (from docstring, if present) |
+| `gen_ai.agent.version` | All decorators (when `version` is set) |
+
+**Supported function types:** sync, async, generators, async generators. Errors are captured as span status + exception events.
+
+```python
+@agent("research_agent", version=2)
+async def research(query: str) -> str:
+    """Agents create invoke_agent spans with gen_ai.agent.* attributes."""
+    result = await search_tool(query)
+    return summarize(result)
+
+@tool("search")
+def search_tool(query: str) -> list:
+    """Docstring becomes gen_ai.tool.description. Input/output use gen_ai.tool.call.* attributes."""
+    return api.search(query)
+```
+
+### `score()`
+
+Submits evaluation scores as OTel spans. Use any evaluation framework you prefer (autoevals, RAGAS, custom) and submit the results through `score()`.
+
+The score span is attached to the evaluated trace so it appears in the same trace waterfall as the spans it evaluates.
+
+**Two scoring levels:**
+
+```python
+# Span-level: score a specific span (score becomes a child of that span)
+score(
+    name="accuracy",
+    value=0.95,
+    trace_id="6ebb9835f43af1552f2cebb9f5165e39",
+    span_id="89829115c2128845",
+    explanation="Weather data matches ground truth",
+    source="heuristic",
+)
+
+# Trace-level: score the entire trace (score attaches to the root span)
+score(
+    name="relevance",
+    value=0.92,
+    trace_id="6ebb9835f43af1552f2cebb9f5165e39",
+    explanation="Response addresses the user's query",
+    source="llm-judge",
+)
+```
+
+**Parameters:**
+
+| Parameter | Type | Description |
+|---|---|---|
+| `name` | `str` | Metric name (e.g., `"relevance"`, `"factuality"`) |
+| `value` | `float` | Numeric score |
+| `trace_id` | `str` | Hex trace ID of the trace being scored |
+| `span_id` | `str` | Hex span ID for span-level scoring. When omitted, attaches to root span |
+| `label` | `str` | Human-readable label (`"pass"`, `"relevant"`, `"correct"`) |
+| `explanation` | `str` | Evaluator justification (truncated to 500 chars) |
+| `response_id` | `str` | LLM completion ID for correlation |
+| `source` | `str` | Score origin: `"sdk"`, `"human"`, `"llm-judge"`, `"heuristic"` |
+| `metadata` | `dict` | Arbitrary key-value metadata |
+
+Scores follow the OTel GenAI semantic conventions with `gen_ai.evaluation.*` attributes.
+
+## Auto-Instrumented Libraries
+
+`register()` automatically discovers and activates any installed instrumentor packages via OTel entry points. No code changes needed — install the extras for the providers you use and their calls are traced automatically.
+
+| Category | Extras / packages |
+|---|---|
+| LLM providers | `[openai]`, `[anthropic]` |
+| Cloud AI | `[bedrock]`, `[google]` (Vertex AI + Generative AI) |
+| Frameworks | `[langchain]`, `[llamaindex]` |
+| All of the above + more | `[otel-instrumentors]` |
+
+`[otel-instrumentors]` includes all of the above plus Cohere, Mistral, Groq, Ollama, Together, Replicate, Writer, Voyage AI, Aleph Alpha, SageMaker, watsonx, Haystack, CrewAI, Agno, MCP, Transformers, ChromaDB, Pinecone, Qdrant, Weaviate, Milvus, LanceDB, and Marqo.
+
+## Configuration
+
+| Environment Variable | Description | Default |
+|---|---|---|
+| `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` | Full OTLP traces endpoint URL | — |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | Base OTLP endpoint URL (`/v1/traces` appended) | — |
+| `OTEL_EXPORTER_OTLP_TRACES_PROTOCOL` | Protocol for traces (`http/protobuf`, `grpc`) | — |
+| `OTEL_EXPORTER_OTLP_PROTOCOL` | Protocol for all signals (`http/protobuf`, `grpc`) | — |
+| `OTEL_SERVICE_NAME` | Service name for spans | `"default"` |
+| `OPENSEARCH_PROJECT` | Project/service name (fallback) | `"default"` |
+| `AWS_DEFAULT_REGION` | AWS region for SigV4 signing | auto-detected |
+
+When no endpoint env var is set, `register()` defaults to the Data Prepper endpoint: `http://localhost:21890/opentelemetry/v1/traces`.
+
+## License
+
+Apache-2.0

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,40 @@
+# Security Policy
+
+## Supported Versions
+
+We support the current major version with security updates.
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 0.2.x   | :white_check_mark: |
+| < 0.2   | :x:                |
+
+## Reporting a Vulnerability
+
+**Please do not report security vulnerabilities through public GitHub issues.**
+
+Instead, please report them via email to: security@opensearch.org
+
+Include the following information:
+- Type of issue (e.g. buffer overflow, SQL injection, etc.)
+- Full paths of source file(s) related to the manifestation of the issue
+- The location of the affected source code (tag/branch/commit or direct URL)
+- Any special configuration required to reproduce the issue
+- Step-by-step instructions to reproduce the issue
+- Proof-of-concept or exploit code (if possible)
+- Impact of the issue, including how an attacker might exploit it
+
+We will acknowledge receipt of your vulnerability report within 48 hours and send a more detailed response within 7 days indicating the next steps in handling your report.
+
+## Security Considerations
+
+When using opensearch-genai-observability-sdk-py:
+
+1. **Credentials**: Ensure AWS credentials are stored securely and follow the principle of least privilege
+2. **Network**: Use HTTPS/TLS for all OTLP connections in production
+3. **Data**: Be mindful of sensitive data in traces - the SDK does not automatically scrub PII
+4. **Dependencies**: Keep dependencies up to date using tools like Dependabot
+
+## Responsible Disclosure
+
+We follow responsible disclosure practices and will work with security researchers to understand and address security vulnerabilities before public disclosure.

--- a/examples/01_tracing_basics.py
+++ b/examples/01_tracing_basics.py
@@ -1,0 +1,66 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+#
+# Modifications Copyright OpenSearch Contributors. See
+# GitHub history for details.
+
+"""Basic tracing with opensearch-genai-observability-sdk-py.
+
+Shows how to register the SDK and trace custom functions
+with @workflow, @task, @agent, and @tool decorators.
+"""
+
+from opensearch_genai_observability_sdk_py import agent, register, task, tool, workflow
+
+# --- Setup ---
+# Local Data Prepper
+register(endpoint="http://localhost:21890/opentelemetry/v1/traces")
+
+# AWS-hosted (SigV4 is auto-detected from the hostname)
+# register(endpoint="https://my-pipeline.us-east-1.osis.amazonaws.com/v1/traces")
+
+
+# --- Decorators ---
+@tool(name="web_search")
+def search(query: str) -> list[dict]:
+    """Simulated web search tool."""
+    return [
+        {"title": f"Result for: {query}", "url": "https://example.com"},
+    ]
+
+
+@task(name="summarize")
+def summarize(text: str) -> str:
+    """Simulated LLM summarization."""
+    return f"Summary of: {text[:100]}"
+
+
+@agent(name="research_agent")
+def research(query: str) -> str:
+    """Agent that searches, then summarizes."""
+    results = search(query)
+    titles = ", ".join(r["title"] for r in results)
+    return summarize(titles)
+
+
+@workflow(name="qa_pipeline")
+def run_pipeline(question: str) -> str:
+    """Top-level workflow that orchestrates the agent."""
+    answer = research(question)
+    return answer
+
+
+# --- Run ---
+if __name__ == "__main__":
+    result = run_pipeline("What is OpenSearch?")
+    print(result)
+
+    # Produces this span tree:
+    #
+    #   qa_pipeline          (workflow)
+    #   └── research_agent   (agent)
+    #       ├── web_search   (tool)
+    #       └── summarize    (task)

--- a/examples/02_scoring.py
+++ b/examples/02_scoring.py
@@ -1,0 +1,74 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+#
+# Modifications Copyright OpenSearch Contributors. See
+# GitHub history for details.
+
+"""Scoring with opensearch-genai-observability-sdk-py.
+
+Shows how to submit evaluation scores as OTEL spans. Scores flow through
+the same exporter pipeline as traces — same SigV4 auth, same Data Prepper
+endpoint. Supports three scoring levels: span, trace, and session.
+"""
+
+from opensearch_genai_observability_sdk_py import register, score
+
+# --- Setup ---
+register(endpoint="http://localhost:21890/opentelemetry/v1/traces")
+
+
+# --- Span-level score (score a specific LLM call or tool execution) ---
+score(
+    name="relevance",
+    value=0.95,
+    trace_id="abc123def456",
+    span_id="789abc",
+    source="llm-judge",
+    explanation="Answer directly addresses the question with correct facts",
+)
+
+
+# --- Trace-level score (score an entire workflow) ---
+score(
+    name="quality",
+    value=0.88,
+    trace_id="abc123def456",
+    label="good",
+    source="human",
+    explanation="Reviewed by QA team, response is accurate and well-formatted",
+)
+
+
+# --- Session-level score (score across multiple traces in a conversation) ---
+score(
+    name="user_satisfaction",
+    value=0.92,
+    conversation_id="session-456",
+    label="satisfied",
+    source="human",
+)
+
+
+# --- Score with metadata ---
+score(
+    name="latency_check",
+    value=1.0,
+    trace_id="abc123def456",
+    source="heuristic",
+    metadata={"threshold_ms": 500, "actual_ms": 120},
+)
+
+
+# Each score() call creates an OTEL span like:
+#
+#   Span: gen_ai.evaluation.result
+#   Attributes:
+#     gen_ai.evaluation.name = "relevance"
+#     gen_ai.evaluation.score.value = 0.95
+#     gen_ai.evaluation.trace_id = "abc123def456"
+#     gen_ai.evaluation.span_id = "789abc"
+#     gen_ai.evaluation.source = "llm-judge"
+#     gen_ai.evaluation.explanation = "Answer directly addresses..."

--- a/examples/05_aws_sigv4.py
+++ b/examples/05_aws_sigv4.py
@@ -1,0 +1,49 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+#
+# Modifications Copyright OpenSearch Contributors. See
+# GitHub history for details.
+
+"""AWS SigV4 authentication with opensearch-genai-observability-sdk-py.
+
+When your Data Prepper or OpenSearch Ingestion pipeline is hosted on AWS,
+pass AWSSigV4OTLPExporter directly to register() via the exporter= parameter.
+
+Requires: pip install opensearch-genai-observability-sdk-py[aws]
+"""
+
+from opensearch_genai_observability_sdk_py import register, score, workflow
+from opensearch_genai_observability_sdk_py.exporters import AWSSigV4OTLPExporter
+
+ENDPOINT = "https://my-pipeline.us-east-1.osis.amazonaws.com/v1/traces"
+
+# Pass AWSSigV4OTLPExporter explicitly.
+# Uses the standard boto3 credential chain (env vars, ~/.aws/credentials, IAM role).
+register(
+    project_name="my-llm-app",
+    exporter=AWSSigV4OTLPExporter(
+        endpoint=ENDPOINT,
+        service="osis",  # "osis" for OpenSearch Ingestion Service
+        # region="us-east-1",   # optional — auto-detected from botocore if not set
+    ),
+)
+
+
+@workflow(name="qa_pipeline")
+def run(question: str) -> str:
+    return f"Answer to: {question}"
+
+
+if __name__ == "__main__":
+    result = run("What is OpenSearch?")
+    print(result)
+
+    score(
+        name="relevance",
+        value=0.9,
+        trace_id="abc123",
+        source="human",
+    )

--- a/examples/06_async_tracing.py
+++ b/examples/06_async_tracing.py
@@ -1,0 +1,47 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+#
+# Modifications Copyright OpenSearch Contributors. See
+# GitHub history for details.
+
+"""Async function tracing with opensearch-genai-observability-sdk-py.
+
+All decorators support async functions natively — no special config.
+"""
+
+import asyncio
+
+from opensearch_genai_observability_sdk_py import register, task, tool, workflow
+
+# --- Setup ---
+register(endpoint="http://localhost:21890/opentelemetry/v1/traces")
+
+
+@tool(name="async_search")
+async def search(query: str) -> list[dict]:
+    """Simulated async API call."""
+    await asyncio.sleep(0.1)  # simulate network latency
+    return [{"title": f"Result: {query}"}]
+
+
+@task(name="async_summarize")
+async def summarize(text: str) -> str:
+    """Simulated async LLM call."""
+    await asyncio.sleep(0.2)
+    return f"Summary: {text[:50]}"
+
+
+@workflow(name="async_pipeline")
+async def run_pipeline(question: str) -> str:
+    """Async workflow — decorators handle async transparently."""
+    results = await search(question)
+    summary = await summarize(str(results))
+    return summary
+
+
+if __name__ == "__main__":
+    result = asyncio.run(run_pipeline("What is OpenSearch?"))
+    print(result)

--- a/examples/07_openai_auto_instrument.py
+++ b/examples/07_openai_auto_instrument.py
@@ -1,0 +1,80 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+#
+# Modifications Copyright OpenSearch Contributors. See
+# GitHub history for details.
+
+"""Auto-instrumentation with opensearch-genai-observability-sdk-py.
+
+register() auto-discovers and activates any installed OpenTelemetry
+or OpenInference instrumentors. Just pip install them — no code changes.
+
+This example shows OpenAI auto-instrumentation: every openai.chat.completions
+call is automatically traced as an OTEL span with gen_ai.* attributes.
+"""
+
+# Step 1: pip install opensearch-genai-observability-sdk-py opentelemetry-instrumentation-openai
+#   (or: pip install opensearch-genai-observability-sdk-py openinference-instrumentation-openai)
+#
+# Both entry point groups are discovered:
+#   - opentelemetry_instrumentor  (OpenLLMetry ecosystem)
+#   - openinference_instrumentor  (Phoenix/Arize ecosystem)
+
+from opensearch_genai_observability_sdk_py import register, workflow
+
+# Step 2: register() auto-instruments all installed libraries
+register(
+    endpoint="http://localhost:21890/opentelemetry/v1/traces",
+    service_name="my-chatbot",
+)
+
+# Step 3: Use OpenAI as normal — calls are traced automatically
+from openai import OpenAI  # noqa: E402
+
+client = OpenAI()
+
+
+@workflow(name="chat")
+def chat(question: str) -> str:
+    """Every OpenAI call inside this workflow is auto-traced."""
+    response = client.chat.completions.create(
+        model="gpt-4o-mini",
+        messages=[{"role": "user", "content": question}],
+    )
+    return response.choices[0].message.content
+
+
+if __name__ == "__main__":
+    answer = chat("What is OpenSearch?")
+    print(answer)
+
+    # Span tree:
+    #
+    #   chat                           (workflow, from @workflow)
+    #   └── openai.chat.completions    (auto-instrumented by OpenLLMetry/OpenInference)
+    #       Attributes:
+    #         gen_ai.system = "openai"
+    #         gen_ai.request.model = "gpt-4o-mini"
+    #         gen_ai.usage.input_tokens = 12
+    #         gen_ai.usage.output_tokens = 87
+    #         gen_ai.response.model = "gpt-4o-mini-2024-07-18"
+
+    # Supported auto-instrumentors (just pip install):
+    #
+    # OpenLLMetry (opentelemetry_instrumentor group):
+    #   opentelemetry-instrumentation-openai
+    #   opentelemetry-instrumentation-anthropic
+    #   opentelemetry-instrumentation-bedrock
+    #   opentelemetry-instrumentation-langchain
+    #   opentelemetry-instrumentation-llamaindex
+    #   opentelemetry-instrumentation-chromadb
+    #   ... 30+ more
+    #
+    # OpenInference (openinference_instrumentor group):
+    #   openinference-instrumentation-openai
+    #   openinference-instrumentation-langchain
+    #   openinference-instrumentation-llama-index
+    #   ... 15+ more

--- a/examples/mini_collector_http.py
+++ b/examples/mini_collector_http.py
@@ -1,0 +1,159 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+#
+# Modifications Copyright OpenSearch Contributors. See
+# GitHub history for details.
+
+"""Mini OTEL Collector — HTTP receiver, prints spans to terminal.
+
+No Docker needed. Receives OTLP/HTTP protobuf on port 4318 and
+pretty-prints every span.
+
+Usage:
+    # Terminal 1: start the collector
+    python examples/mini_collector_http.py
+
+    # Terminal 2: run the agent
+    python examples/agent_http.py
+"""
+
+import uvicorn
+from fastapi import FastAPI, Request, Response
+from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import (
+    ExportTraceServiceRequest,
+    ExportTraceServiceResponse,
+)
+
+app = FastAPI()
+
+# Colors for terminal output
+CYAN = "\033[96m"
+GREEN = "\033[92m"
+YELLOW = "\033[93m"
+MAGENTA = "\033[95m"
+RED = "\033[91m"
+RESET = "\033[0m"
+BOLD = "\033[1m"
+DIM = "\033[2m"
+
+SPAN_KIND_MAP = {
+    "workflow": f"{MAGENTA}workflow{RESET}",
+    "invoke_agent": f"{CYAN}agent{RESET}",
+    "task": f"{GREEN}task{RESET}",
+    "execute_tool": f"{YELLOW}tool{RESET}",
+}
+
+
+def format_trace_id(tid: bytes) -> str:
+    return tid.hex()
+
+
+def format_span_id(sid: bytes) -> str:
+    return sid.hex()
+
+
+def ns_to_ms(ns: int) -> float:
+    return ns / 1_000_000
+
+
+def print_span(span, resource_attrs: dict):
+    """Pretty-print a single span."""
+    attrs = {}
+    for kv in span.attributes:
+        key = kv.key
+        val = kv.value
+        if val.HasField("string_value"):
+            attrs[key] = val.string_value
+        elif val.HasField("int_value"):
+            attrs[key] = val.int_value
+        elif val.HasField("double_value"):
+            attrs[key] = val.double_value
+        elif val.HasField("bool_value"):
+            attrs[key] = val.bool_value
+        else:
+            attrs[key] = str(val)
+
+    span_kind = attrs.get("gen_ai.operation.name", "")
+    is_score = "gen_ai.evaluation.name" in attrs
+    kind_label = SPAN_KIND_MAP.get(span_kind, f"{RED}score{RESET}" if is_score else "internal")
+
+    trace_id = format_trace_id(span.trace_id)
+    span_id = format_span_id(span.span_id)
+    parent_id = format_span_id(span.parent_span_id) if span.parent_span_id else "none (root)"
+    duration_ms = ns_to_ms(span.end_time_unix_nano - span.start_time_unix_nano)
+    service = resource_attrs.get("service.name", "unknown")
+
+    print(f"\n{BOLD}{'─' * 70}{RESET}")
+    print(f"  {BOLD}Span:{RESET} {span.name}  [{kind_label}]  {DIM}{duration_ms:.1f}ms{RESET}")
+    print(f"  {DIM}Trace:  {trace_id}{RESET}")
+    print(f"  {DIM}Span:   {span_id}{RESET}")
+    print(f"  {DIM}Parent: {parent_id}{RESET}")
+    print(f"  {DIM}Service: {service}{RESET}")
+
+    # Print interesting attributes
+    for key in [
+        "gen_ai.entity.input",
+        "gen_ai.entity.output",
+        "gen_ai.tool.call.arguments",
+        "gen_ai.tool.call.result",
+        "gen_ai.evaluation.name",
+        "gen_ai.evaluation.score.value",
+        "gen_ai.evaluation.source",
+        "gen_ai.evaluation.explanation",
+        "gen_ai.evaluation.trace_id",
+        "gen_ai.evaluation.span_id",
+        "gen_ai.conversation.id",
+    ]:
+        if key in attrs:
+            val = attrs[key]
+            # Truncate long values
+            val_str = str(val)
+            if len(val_str) > 120:
+                val_str = val_str[:120] + "..."
+            print(f"  {CYAN}{key}{RESET}: {val_str}")
+
+
+@app.post("/v1/traces")
+async def receive_traces(request: Request):
+    """OTLP/HTTP trace receiver."""
+    body = await request.body()
+
+    req = ExportTraceServiceRequest()
+    req.ParseFromString(body)
+
+    span_count = 0
+    for resource_spans in req.resource_spans:
+        # Extract resource attributes
+        resource_attrs = {}
+        for kv in resource_spans.resource.attributes:
+            if kv.value.HasField("string_value"):
+                resource_attrs[kv.key] = kv.value.string_value
+
+        for scope_spans in resource_spans.scope_spans:
+            for span in scope_spans.spans:
+                print_span(span, resource_attrs)
+                span_count += 1
+
+    if span_count > 0:
+        print(f"\n{GREEN}✓ Received {span_count} span(s) via HTTP{RESET}\n")
+
+    resp = ExportTraceServiceResponse()
+    return Response(
+        content=resp.SerializeToString(),
+        media_type="application/x-protobuf",
+    )
+
+
+if __name__ == "__main__":
+    print(f"{BOLD}{'=' * 70}{RESET}")
+    print(f"{BOLD}  Mini OTEL Collector — HTTP on port 4318{RESET}")
+    print(f"{BOLD}{'=' * 70}{RESET}")
+    print("  Listening: http://0.0.0.0:4318/v1/traces")
+    print("  Protocol:  OTLP/HTTP (protobuf)")
+    print()
+    print("  Test with: python examples/agent_http.py")
+    print(f"{BOLD}{'=' * 70}{RESET}\n")
+    uvicorn.run(app, host="0.0.0.0", port=4318, log_level="warning")  # noqa: S104

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,146 @@
+[project]
+name = "opensearch-genai-observability-sdk-py"
+version = "0.2.6"
+description = "OpenSearch AI Observability SDK — OTEL-native tracing and scoring for LLM applications"
+authors = [
+    { name = "OpenSearch Contributors" },
+]
+license = "Apache-2.0"
+readme = "README.md"
+requires-python = ">=3.10,<4"
+keywords = ["opentelemetry", "tracing", "llm", "ai", "observability", "opensearch", "genai"]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: Apache Software License",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+    "Topic :: System :: Monitoring",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+]
+dependencies = [
+    "opentelemetry-api>=1.20.0,<2",
+    "opentelemetry-sdk>=1.20.0,<2",
+    "opentelemetry-exporter-otlp-proto-http>=1.20.0,<2",
+    "opentelemetry-exporter-otlp-proto-grpc>=1.20.0,<2",
+    "botocore>=1.29.0",
+]
+
+[project.optional-dependencies]
+
+# Individual extras for popular providers.
+# auto_instrument=True in register() picks up whichever ones are installed.
+openai = [
+    "opentelemetry-instrumentation-openai>=0.52.0",
+    "opentelemetry-instrumentation-openai-agents>=0.52.0",
+]
+anthropic = [
+    "opentelemetry-instrumentation-anthropic>=0.52.0",
+]
+bedrock = [
+    "opentelemetry-instrumentation-bedrock>=0.52.0",
+]
+google = [
+    "opentelemetry-instrumentation-google-generativeai>=0.52.0",
+    "opentelemetry-instrumentation-vertexai>=0.52.0",
+]
+langchain = [
+    "opentelemetry-instrumentation-langchain>=0.52.0",
+]
+llamaindex = [
+    "opentelemetry-instrumentation-llamaindex>=0.52.0",
+]
+# All instrumentors at once.
+otel-instrumentors = [
+    "opentelemetry-instrumentation-openai>=0.52.0",
+    "opentelemetry-instrumentation-openai-agents>=0.52.0",
+    "opentelemetry-instrumentation-anthropic>=0.52.0",
+    "opentelemetry-instrumentation-cohere>=0.52.0",
+    "opentelemetry-instrumentation-mistralai>=0.52.0",
+    "opentelemetry-instrumentation-groq>=0.52.0",
+    "opentelemetry-instrumentation-ollama>=0.52.0",
+    "opentelemetry-instrumentation-together>=0.52.0",
+    "opentelemetry-instrumentation-replicate>=0.52.0",
+    "opentelemetry-instrumentation-writer>=0.52.0",
+    "opentelemetry-instrumentation-google-generativeai>=0.52.0",
+    "opentelemetry-instrumentation-vertexai>=0.52.0",
+    "opentelemetry-instrumentation-voyageai>=0.52.0",
+    "opentelemetry-instrumentation-alephalpha>=0.52.0",
+    "opentelemetry-instrumentation-bedrock>=0.52.0",
+    "opentelemetry-instrumentation-sagemaker>=0.52.0",
+    "opentelemetry-instrumentation-watsonx>=0.52.0",
+    "opentelemetry-instrumentation-langchain>=0.52.0",
+    "opentelemetry-instrumentation-llamaindex>=0.52.0",
+    "opentelemetry-instrumentation-haystack>=0.52.0",
+    "opentelemetry-instrumentation-crewai>=0.52.0",
+    "opentelemetry-instrumentation-agno>=0.52.0",
+    "opentelemetry-instrumentation-mcp>=0.52.0",
+    "opentelemetry-instrumentation-transformers>=0.52.0",
+    "opentelemetry-instrumentation-chromadb>=0.52.0",
+    "opentelemetry-instrumentation-pinecone>=0.52.0",
+    "opentelemetry-instrumentation-qdrant>=0.52.0",
+    "opentelemetry-instrumentation-weaviate>=0.52.0",
+    "opentelemetry-instrumentation-milvus>=0.52.0",
+    "opentelemetry-instrumentation-lancedb>=0.52.0",
+    "opentelemetry-instrumentation-marqo>=0.52.0",
+]
+dev = [
+    "pytest>=7.0",
+    "pytest-asyncio>=0.21",
+    "pytest-cov>=4.0",
+    "ruff>=0.1.0",
+    "mypy>=1.5.0",
+    "bandit>=1.7.5",
+    "safety>=2.3.0",
+    "pre-commit>=3.0.0",
+]
+# Everything — for development and integration testing.
+all = [
+    "opensearch-genai-observability-sdk-py[otel-instrumentors,dev]",
+]
+
+[project.urls]
+Repository = "https://github.com/opensearch-project/genai-observability-sdk-py"
+Homepage = "https://github.com/opensearch-project/genai-observability-sdk-py"
+Documentation = "https://github.com/opensearch-project/genai-observability-sdk-py#readme"
+"Bug Tracker" = "https://github.com/opensearch-project/genai-observability-sdk-py/issues"
+Changelog = "https://github.com/opensearch-project/genai-observability-sdk-py/blob/main/CHANGELOG.md"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/opensearch_genai_observability_sdk_py"]
+
+[tool.hatch.build.targets.sdist]
+exclude = ["examples/", "tests/"]
+
+[tool.ruff]
+line-length = 100
+target-version = "py310"
+
+[tool.ruff.lint]
+select = ["E", "F", "W", "I", "N", "UP", "S", "B"]
+ignore = [
+    "S101",  # Use of assert detected (OK in tests)
+    "S113",  # Probable use of requests without timeout (handled by OTEL SDK)
+]
+
+[tool.mypy]
+python_version = "3.10"
+warn_return_any = true
+warn_unused_configs = true
+disallow_untyped_defs = true
+ignore_missing_imports = true
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+python_files = "test_*.py"
+python_functions = "test_*"
+addopts = "-v --tb=short"

--- a/src/opensearch_genai_observability_sdk_py/__init__.py
+++ b/src/opensearch_genai_observability_sdk_py/__init__.py
@@ -1,0 +1,32 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+#
+# Modifications Copyright OpenSearch Contributors. See
+# GitHub history for details.
+
+"""OpenSearch AI Observability SDK.
+
+OTEL-native tracing and scoring for LLM applications.
+"""
+
+from opensearch_genai_observability_sdk_py.decorators import agent, task, tool, workflow
+from opensearch_genai_observability_sdk_py.exporters import AWSSigV4OTLPExporter
+from opensearch_genai_observability_sdk_py.register import register
+from opensearch_genai_observability_sdk_py.score import score
+
+__all__ = [
+    # Setup
+    "register",
+    # Decorators
+    "workflow",
+    "task",
+    "agent",
+    "tool",
+    # Scoring
+    "score",
+    # Exporters
+    "AWSSigV4OTLPExporter",
+]

--- a/src/opensearch_genai_observability_sdk_py/decorators.py
+++ b/src/opensearch_genai_observability_sdk_py/decorators.py
@@ -1,0 +1,431 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+#
+# Modifications Copyright OpenSearch Contributors. See
+# GitHub history for details.
+
+"""Decorators for tracing custom functions as OTEL spans.
+
+Provides @workflow, @task, @agent, and @tool decorators that create
+standard OpenTelemetry spans. These are the user-facing API for
+tracing custom application logic — the gap that pure auto-instrumentors
+don't cover.
+
+All decorators produce standard OTEL spans with gen_ai semantic
+convention attributes. Zero lock-in: remove the decorator and
+your code still works.
+"""
+
+from __future__ import annotations
+
+import functools
+import inspect
+import json
+import logging
+from collections.abc import Callable
+from typing import Any, TypeVar
+
+from opentelemetry import trace
+from opentelemetry.trace import SpanKind
+
+logger = logging.getLogger(__name__)
+
+F = TypeVar("F", bound=Callable[..., Any])
+
+# Internal decorator type identifiers (used for attribute routing and span naming)
+SPAN_KIND_WORKFLOW = "workflow"
+SPAN_KIND_TASK = "task"
+SPAN_KIND_AGENT = "invoke_agent"
+SPAN_KIND_TOOL = "execute_tool"
+
+# gen_ai.operation.name values per OTEL GenAI semantic conventions
+# workflow and task both map to invoke_agent (no workflow/task values in semconv)
+_OPERATION_NAME = {
+    SPAN_KIND_WORKFLOW: "invoke_agent",
+    SPAN_KIND_TASK: "invoke_agent",
+    SPAN_KIND_AGENT: "invoke_agent",
+    SPAN_KIND_TOOL: "execute_tool",
+}
+
+# Default OTel SpanKind per decorator type.
+# agent uses CLIENT because it typically represents a call out to an LLM/agent service.
+# tool uses INTERNAL because tool execution happens within the process.
+_DEFAULT_OTEL_KIND = {
+    SPAN_KIND_WORKFLOW: SpanKind.INTERNAL,
+    SPAN_KIND_TASK: SpanKind.INTERNAL,
+    SPAN_KIND_AGENT: SpanKind.CLIENT,
+    SPAN_KIND_TOOL: SpanKind.INTERNAL,
+}
+
+_TRACER_NAME = "opensearch-genai-observability-sdk-py"
+
+
+def workflow(
+    name: str | None = None,
+    version: int | None = None,
+    kind: SpanKind | None = None,
+    name_from: str | None = None,
+) -> Callable[[F], F]:
+    """Trace a function as a workflow span.
+
+    Use for top-level orchestration functions that coordinate
+    multiple tasks, agents, or tool calls.
+
+    Args:
+        name: Span name. Defaults to the function's qualified name.
+        version: Optional version number for tracking changes.
+        kind: Override the OTel SpanKind. Defaults to INTERNAL.
+        name_from: Name of a function parameter whose runtime value is used
+            as the entity name. Useful for dispatcher functions where the
+            logical name isn't known until call time.
+
+    Example:
+        @workflow(name="qa_pipeline")
+        def run_pipeline(query: str) -> str:
+            plan = plan_steps(query)
+            result = execute(plan)
+            return result
+    """
+    return _make_decorator(
+        name=name,
+        version=version,
+        span_kind=SPAN_KIND_WORKFLOW,
+        otel_kind=kind,
+        name_from=name_from,
+    )
+
+
+def task(
+    name: str | None = None,
+    version: int | None = None,
+    kind: SpanKind | None = None,
+    name_from: str | None = None,
+) -> Callable[[F], F]:
+    """Trace a function as a task span.
+
+    Use for individual units of work within a workflow.
+
+    Args:
+        name: Span name. Defaults to the function's qualified name.
+        version: Optional version number for tracking changes.
+        kind: Override the OTel SpanKind. Defaults to INTERNAL.
+        name_from: Name of a function parameter whose runtime value is used
+            as the entity name.
+
+    Example:
+        @task(name="summarize")
+        def summarize_text(text: str) -> str:
+            return llm.generate(f"Summarize: {text}")
+    """
+    return _make_decorator(
+        name=name, version=version, span_kind=SPAN_KIND_TASK, otel_kind=kind, name_from=name_from
+    )
+
+
+def agent(
+    name: str | None = None,
+    version: int | None = None,
+    kind: SpanKind | None = None,
+    name_from: str | None = None,
+) -> Callable[[F], F]:
+    """Trace a function as an agent span (SpanKind.CLIENT by default).
+
+    Use for autonomous agent logic that makes decisions and invokes tools.
+    Defaults to SpanKind.CLIENT because agent invocations typically represent
+    a call out to an external LLM or agent service.
+
+    Args:
+        name: Span name. Defaults to the function's qualified name.
+        version: Optional version number for tracking changes.
+        kind: Override the OTel SpanKind. Defaults to CLIENT.
+        name_from: Name of a function parameter whose runtime value is used
+            as the entity name.
+
+    Example:
+        @agent(name="research_agent")
+        def research(query: str) -> str:
+            while not done:
+                action = decide_next_action(query)
+                result = execute_action(action)
+            return result
+    """
+    return _make_decorator(
+        name=name, version=version, span_kind=SPAN_KIND_AGENT, otel_kind=kind, name_from=name_from
+    )
+
+
+def tool(
+    name: str | None = None,
+    version: int | None = None,
+    kind: SpanKind | None = None,
+    name_from: str | None = None,
+) -> Callable[[F], F]:
+    """Trace a function as a tool span.
+
+    Use for tool/function calls invoked by agents.
+
+    Args:
+        name: Span name. Defaults to the function's qualified name.
+        version: Optional version number for tracking changes.
+        kind: Override the OTel SpanKind. Defaults to INTERNAL.
+        name_from: Name of a function parameter whose runtime value is used
+            as the entity name and span name. Useful for dispatcher methods
+            where the actual tool name is a runtime argument.
+
+    Example — static tool:
+        @tool(name="web_search")
+        def search(query: str) -> list[dict]:
+            return search_api.query(query)
+
+    Example — dispatcher with dynamic tool name:
+        @tool(name_from="tool_name")
+        def execute_tool(self, tool_name: str, arguments: dict) -> dict:
+            ...
+    """
+    return _make_decorator(
+        name=name, version=version, span_kind=SPAN_KIND_TOOL, otel_kind=kind, name_from=name_from
+    )
+
+
+def _make_decorator(
+    name: str | None,
+    version: int | None,
+    span_kind: str,
+    otel_kind: SpanKind | None,
+    name_from: str | None,
+) -> Callable[[F], F]:
+    """Create a decorator that wraps a function in an OTEL span."""
+
+    resolved_otel_kind = otel_kind if otel_kind is not None else _DEFAULT_OTEL_KIND[span_kind]
+
+    def decorator(fn: F) -> F:
+        static_entity_name = name or fn.__qualname__
+        fn_doc = fn.__doc__
+        sig = inspect.signature(fn)
+        # NOTE: tracer is intentionally fetched inside each wrapper (at call
+        # time), NOT here at decoration time.  The OTEL ProxyTracer caches
+        # the backing tracer on first use; fetching it here would lock in
+        # whatever provider is active at import time (often the no-op default)
+        # before register() has been called.  Fetching at call time ensures
+        # the wrapper always uses the provider that is current when the
+        # function is actually invoked.
+
+        def _resolve_names(args: Any, kwargs: Any) -> tuple[str, str]:
+            """Resolve entity name and span name at call time."""
+            entity = static_entity_name
+            if name_from:
+                try:
+                    bound = sig.bind(*args, **kwargs)
+                    bound.apply_defaults()
+                    runtime_val = bound.arguments.get(name_from)
+                    if runtime_val is not None:
+                        entity = str(runtime_val)
+                except TypeError:
+                    pass
+            if span_kind in (SPAN_KIND_AGENT, SPAN_KIND_TOOL):
+                span_name = f"{span_kind} {entity}"
+            else:
+                span_name = entity
+            return entity, span_name
+
+        if inspect.iscoroutinefunction(fn):
+
+            @functools.wraps(fn)
+            async def async_wrapper(*args: Any, **kwargs: Any) -> Any:
+                entity_name, span_name = _resolve_names(args, kwargs)
+                tracer = trace.get_tracer(_TRACER_NAME)
+                with tracer.start_as_current_span(span_name, kind=resolved_otel_kind) as span:
+                    _set_span_attributes(
+                        span, span_kind, entity_name, version, sig, args, kwargs, fn_doc
+                    )
+                    try:
+                        result = await fn(*args, **kwargs)
+                        _set_output(span, span_kind, result)
+                        return result
+                    except Exception as exc:
+                        span.set_status(trace.StatusCode.ERROR, str(exc))
+                        span.record_exception(exc)
+                        raise
+
+            return async_wrapper  # type: ignore[return-value]
+
+        elif inspect.isgeneratorfunction(fn):
+
+            @functools.wraps(fn)
+            def gen_wrapper(*args: Any, **kwargs: Any) -> Any:
+                entity_name, span_name = _resolve_names(args, kwargs)
+                tracer = trace.get_tracer(_TRACER_NAME)
+                with tracer.start_as_current_span(span_name, kind=resolved_otel_kind) as span:
+                    _set_span_attributes(
+                        span, span_kind, entity_name, version, sig, args, kwargs, fn_doc
+                    )
+                    try:
+                        collected = []
+                        for item in fn(*args, **kwargs):
+                            collected.append(item)
+                            yield item
+                        _set_output(span, span_kind, collected)
+                    except Exception as exc:
+                        span.set_status(trace.StatusCode.ERROR, str(exc))
+                        span.record_exception(exc)
+                        raise
+
+            return gen_wrapper  # type: ignore[return-value]
+
+        elif inspect.isasyncgenfunction(fn):
+
+            @functools.wraps(fn)
+            async def async_gen_wrapper(*args: Any, **kwargs: Any) -> Any:
+                entity_name, span_name = _resolve_names(args, kwargs)
+                tracer = trace.get_tracer(_TRACER_NAME)
+                with tracer.start_as_current_span(span_name, kind=resolved_otel_kind) as span:
+                    _set_span_attributes(
+                        span, span_kind, entity_name, version, sig, args, kwargs, fn_doc
+                    )
+                    try:
+                        collected = []
+                        async for item in fn(*args, **kwargs):
+                            collected.append(item)
+                            yield item
+                        _set_output(span, span_kind, collected)
+                    except Exception as exc:
+                        span.set_status(trace.StatusCode.ERROR, str(exc))
+                        span.record_exception(exc)
+                        raise
+
+            return async_gen_wrapper  # type: ignore[return-value]
+
+        else:
+
+            @functools.wraps(fn)
+            def sync_wrapper(*args: Any, **kwargs: Any) -> Any:
+                entity_name, span_name = _resolve_names(args, kwargs)
+                tracer = trace.get_tracer(_TRACER_NAME)
+                with tracer.start_as_current_span(span_name, kind=resolved_otel_kind) as span:
+                    _set_span_attributes(
+                        span, span_kind, entity_name, version, sig, args, kwargs, fn_doc
+                    )
+                    try:
+                        result = fn(*args, **kwargs)
+                        _set_output(span, span_kind, result)
+                        return result
+                    except Exception as exc:
+                        span.set_status(trace.StatusCode.ERROR, str(exc))
+                        span.record_exception(exc)
+                        raise
+
+            return sync_wrapper  # type: ignore[return-value]
+
+    return decorator
+
+
+def _set_span_attributes(
+    span: trace.Span,
+    span_kind: str,
+    entity_name: str,
+    version: int | None,
+    sig: inspect.Signature,
+    args: tuple,
+    kwargs: dict,
+    fn_doc: str | None = None,
+) -> None:
+    """Set standard attributes on a span."""
+    span.set_attribute("gen_ai.operation.name", _OPERATION_NAME[span_kind])
+
+    # Use type-specific name attributes matching gen_ai semantic conventions
+    # workflow and task use gen_ai.agent.name (no workflow/task name attrs in semconv)
+    _name_attr = {
+        SPAN_KIND_WORKFLOW: "gen_ai.agent.name",
+        SPAN_KIND_TASK: "gen_ai.agent.name",
+        SPAN_KIND_AGENT: "gen_ai.agent.name",
+        SPAN_KIND_TOOL: "gen_ai.tool.name",
+    }
+    span.set_attribute(_name_attr[span_kind], entity_name)
+
+    if version is not None:
+        span.set_attribute("gen_ai.agent.version", str(version))
+
+    # Tool-specific attributes from semconv
+    if span_kind == SPAN_KIND_TOOL:
+        span.set_attribute("gen_ai.tool.type", "function")
+        if fn_doc:
+            # Use first non-empty line of docstring
+            first_line = next(
+                (ln.strip() for ln in fn_doc.splitlines() if ln.strip()), fn_doc[:200]
+            )
+            span.set_attribute("gen_ai.tool.description", first_line)
+
+    # Capture input (best-effort, don't fail if serialization fails)
+    _set_input(span, span_kind, sig, args, kwargs)
+
+
+def _set_input(
+    span: trace.Span, span_kind: str, sig: inspect.Signature, args: tuple, kwargs: dict
+) -> None:
+    """Attempt to capture function input as a span attribute.
+
+    Binds positional and keyword arguments to their parameter names
+    so the trace shows {"city": "Paris"} instead of just "Paris".
+    Skips 'self' and 'cls' parameters for class methods.
+    """
+    try:
+        if not args and not kwargs:
+            return
+
+        # Bind args to parameter names for readable output
+        try:
+            bound = sig.bind(*args, **kwargs)
+            bound.apply_defaults()
+            # Skip 'self' and 'cls' — not useful in traces and not serializable
+            value = {k: v for k, v in bound.arguments.items() if k not in ("self", "cls")}
+        except TypeError:
+            # Fallback if binding fails (e.g., *args/**kwargs signatures)
+            value = {"args": list(args), "kwargs": kwargs}
+
+        serialized = json.dumps(value, default=str)
+        # Truncate to avoid oversized attributes
+        if len(serialized) > 10_000:
+            serialized = serialized[:10_000] + "...(truncated)"
+
+        # Tool spans use semconv attribute name; all others use gen_ai.input.messages
+        attr_key = (
+            "gen_ai.tool.call.arguments" if span_kind == SPAN_KIND_TOOL else "gen_ai.input.messages"
+        )
+        span.set_attribute(attr_key, serialized)
+    except Exception:  # noqa: S110
+        pass
+
+
+def _set_output(span: trace.Span, span_kind: str, result: Any) -> None:
+    """Attempt to capture function output as a span attribute.
+
+    Skips setting the attribute if the user already set it inside the function
+    body (via trace.get_current_span().set_attribute(...)), so that custom
+    formatting (e.g. genai role/parts schema) is not overwritten.
+    """
+    try:
+        if result is None:
+            return
+
+        attr_key = (
+            "gen_ai.tool.call.result" if span_kind == SPAN_KIND_TOOL else "gen_ai.output.messages"
+        )
+
+        # Don't overwrite a value the user already set inside the function body.
+        # span.attributes is the public ReadableSpan property, accessible on a live
+        # recording span. getattr is used because trace.Span (the interface) does not
+        # declare attributes — only the SDK implementation does.
+        existing = getattr(span, "attributes", None)
+        if existing and attr_key in existing:
+            return
+
+        serialized = json.dumps(result, default=str)
+        if len(serialized) > 10_000:
+            serialized = serialized[:10_000] + "...(truncated)"
+
+        span.set_attribute(attr_key, serialized)
+    except Exception:  # noqa: S110
+        pass

--- a/src/opensearch_genai_observability_sdk_py/exporters.py
+++ b/src/opensearch_genai_observability_sdk_py/exporters.py
@@ -1,0 +1,161 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+#
+# Modifications Copyright OpenSearch Contributors. See
+# GitHub history for details.
+
+"""OTLP span exporters with AWS SigV4 support.
+
+Provides a drop-in replacement for OTLPSpanExporter that signs
+requests using AWS Signature Version 4 for AWS-hosted OpenSearch
+and Data Prepper endpoints.
+
+Design note
+-----------
+The previous implementation signed a *synthetic* request with an empty body
+(``data=b""``) and patched the Authorization header onto the exporter's
+internal ``_session``. That approach was incorrect: AWS SigV4 includes
+``SHA256(body)`` in the canonical request, so signing over an empty body
+while sending a non-empty protobuf payload produces a body-hash mismatch
+and a ``403 SignatureDoesNotMatch`` from AWS.
+
+The fix (same approach as aws-otel-python-instrumentation) is to subclass
+``requests.Session`` and override ``request()``.  By the time ``request()``
+is called, the OTLP exporter has already serialized the spans into protobuf
+bytes and passed them as ``data=``.  We sign over that real payload, so the
+body hash in the Authorization header always matches what AWS receives.
+
+``OTLPSpanExporter`` (and its parent ``OTLPExporterMixin``) accept a
+``session=`` constructor argument and use it for all HTTP calls, so there
+is no need to override ``export()`` or touch ``_session`` after init.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import requests  # type: ignore[import-untyped]
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+
+logger = logging.getLogger(__name__)
+
+
+class _SigV4AuthSession(requests.Session):
+    """A ``requests.Session`` that signs every request with AWS SigV4.
+
+    Signing happens inside ``request()``, at which point the real
+    serialized body (protobuf bytes) is available as ``data=``.  This
+    ensures the body hash in the Authorization header always matches
+    the payload that AWS actually receives.
+    """
+
+    def __init__(self, credentials: Any, service: str, region: str) -> None:
+        super().__init__()
+        self._credentials = credentials
+        self._service = service
+        self._region = region
+
+    def request(
+        self,
+        method: str,
+        url: str,
+        *args: Any,
+        data: Any = None,
+        headers: Any = None,
+        **kwargs: Any,
+    ) -> Any:  # noqa: E501
+        import botocore.auth
+        from botocore.awsrequest import AWSRequest
+
+        frozen = self._credentials.get_frozen_credentials()
+        signer = botocore.auth.SigV4Auth(frozen, self._service, self._region)
+
+        # Sign over the real body so the SHA256 payload hash is correct.
+        aws_request = AWSRequest(
+            method=method,
+            url=url,
+            data=data if data is not None else b"",
+            headers={"Content-Type": "application/x-protobuf"},
+        )
+        signer.add_auth(aws_request)
+
+        # Merge all SigV4 headers into the headers that will be sent.
+        # Copy every header botocore added (Authorization, X-Amz-Date,
+        # X-Amz-Security-Token, X-Amz-Content-Sha256, etc.) — OSIS requires
+        # X-Amz-Content-Sha256 and will drop the connection if it is missing.
+        if headers is None:
+            headers = {}
+        for key, value in aws_request.headers.items():
+            if key.lower() != "content-type":  # already set by the OTLP exporter
+                headers[key] = value
+
+        return super().request(*args, method=method, url=url, data=data, headers=headers, **kwargs)
+
+
+class AWSSigV4OTLPExporter(OTLPSpanExporter):
+    """OTLP HTTP span exporter that signs requests with AWS SigV4.
+
+    Uses botocore's credential chain (env vars, ~/.aws/credentials,
+    IAM roles, IMDS) to resolve credentials automatically.
+
+    A ``_SigV4AuthSession`` is passed to the parent ``OTLPSpanExporter``
+    via the ``session=`` constructor argument.  All HTTP calls go through
+    that session, so every export is signed over the real protobuf body.
+
+    Args:
+        endpoint: The OTLP endpoint URL.
+        service: The AWS service name for signing. Use "osis" for
+            OpenSearch Ingestion, "es" for OpenSearch Service direct.
+        region: AWS region. Auto-detected from botocore if not provided.
+        **kwargs: Additional arguments passed to OTLPSpanExporter.
+
+    Example:
+        exporter = AWSSigV4OTLPExporter(
+            endpoint="https://pipeline.us-east-1.osis.amazonaws.com/v1/traces",
+            service="osis",
+        )
+    """
+
+    def __init__(
+        self,
+        *args: Any,
+        service: str = "osis",
+        region: str | None = None,
+        **kwargs: Any,
+    ) -> None:
+        import botocore.session
+
+        botocore_session = botocore.session.get_session()
+        credentials = botocore_session.get_credentials()
+        resolved_region = region or botocore_session.get_config_variable("region")
+
+        if not credentials:
+            raise RuntimeError(
+                "No AWS credentials found. Configure credentials via environment "
+                "variables (AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY), "
+                "~/.aws/credentials, or an IAM role."
+            )
+        if not resolved_region:
+            raise RuntimeError(
+                "No AWS region found. Set the region via the 'region' parameter, "
+                "AWS_DEFAULT_REGION environment variable, or ~/.aws/config."
+            )
+
+        # Pass the signing session to OTLPSpanExporter.  The parent stores it
+        # as self._session and routes all HTTP calls through it.
+        kwargs["session"] = _SigV4AuthSession(
+            credentials=credentials,
+            service=service,
+            region=resolved_region,
+        )
+        super().__init__(*args, **kwargs)
+
+        logger.info(
+            "AWSSigV4OTLPExporter initialized for service=%s region=%s",
+            service,
+            resolved_region,
+        )

--- a/src/opensearch_genai_observability_sdk_py/register.py
+++ b/src/opensearch_genai_observability_sdk_py/register.py
@@ -1,0 +1,416 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+#
+# Modifications Copyright OpenSearch Contributors. See
+# GitHub history for details.
+
+"""OTel pipeline setup for OpenSearch AI observability.
+
+The register() function is the single entry point for configuring
+tracing. It creates a TracerProvider, sets up the exporter, and
+auto-discovers installed instrumentor packages.
+
+Endpoint resolution (priority order)
+-------------------------------------
+1. ``endpoint=`` parameter — full URL, used as-is.
+2. ``OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`` env var — full URL, used as-is.
+3. ``OTEL_EXPORTER_OTLP_ENDPOINT`` env var — base URL; ``/v1/traces`` is
+   appended automatically (per the OTel spec).
+4. Data Prepper default: ``http://localhost:21890/opentelemetry/v1/traces``
+
+Protocol resolution (priority order)
+--------------------------------------
+1. ``protocol=`` parameter — ``"http"`` or ``"grpc"``.
+2. ``OTEL_EXPORTER_OTLP_TRACES_PROTOCOL`` env var.
+3. ``OTEL_EXPORTER_OTLP_PROTOCOL`` env var.
+4. Inferred from URL scheme: ``grpc://`` / ``grpcs://`` → gRPC;
+   everything else (``http://``, ``https://``) → HTTP.
+
+Supported protocols
+--------------------
+- ``http://`` / ``https://`` → HTTP OTLP (protobuf)
+- ``grpc://`` → gRPC (insecure)
+- ``grpcs://`` → gRPC with TLS
+
+``http/json`` is not supported.
+
+Raises ``ValueError`` if the explicit protocol contradicts an unambiguous
+``grpc://`` or ``grpcs://`` URL scheme.
+
+For authenticated endpoints (e.g. AWS OSIS), pass a custom exporter:
+
+    from opensearch_genai_observability_sdk_py.exporters import AWSSigV4OTLPExporter
+
+    register(
+        exporter=AWSSigV4OTLPExporter(
+            endpoint="https://pipeline.us-east-1.osis.amazonaws.com/v1/traces",
+            service="osis",
+        )
+    )
+
+Note: AWSSigV4OTLPExporter is HTTP-only. AWS OSIS does not expose a gRPC
+endpoint.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from importlib.metadata import entry_points
+from typing import Literal
+from urllib.parse import urlparse
+
+from opentelemetry import trace
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import (
+    BatchSpanProcessor,
+    SimpleSpanProcessor,
+    SpanExporter,
+    SpanProcessor,
+)
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_ENDPOINT = "http://localhost:21890/opentelemetry/v1/traces"
+
+# Entry point group to discover instrumentors from.
+# OpenLLMetry + official OTel instrumentors register under this group.
+_INSTRUMENTOR_GROUPS = [
+    "opentelemetry_instrumentor",
+]
+
+
+def register(
+    *,
+    endpoint: str | None = None,
+    protocol: Literal["http", "grpc"] | None = None,
+    project_name: str | None = None,
+    service_name: str | None = None,
+    batch: bool = True,
+    auto_instrument: bool = True,
+    exporter: SpanExporter | None = None,
+    set_global: bool = True,
+    headers: dict | None = None,
+) -> TracerProvider:
+    """Configure the OTel tracing pipeline for OpenSearch.
+
+    One-line setup that creates a TracerProvider, configures an OTLP
+    exporter, and auto-discovers installed instrumentor packages.
+
+    Endpoint resolution (priority order):
+
+    1. ``endpoint=`` parameter (full URL, used as-is)
+    2. ``OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`` env var (full URL, used as-is)
+    3. ``OTEL_EXPORTER_OTLP_ENDPOINT`` env var (base URL, ``/v1/traces`` appended)
+    4. ``http://localhost:21890/opentelemetry/v1/traces`` (Data Prepper default)
+
+    Protocol resolution (priority order):
+
+    1. ``protocol=`` parameter
+    2. ``OTEL_EXPORTER_OTLP_TRACES_PROTOCOL`` env var
+    3. ``OTEL_EXPORTER_OTLP_PROTOCOL`` env var
+    4. Inferred from URL scheme (``grpc://`` / ``grpcs://`` → gRPC; else HTTP)
+
+    Supported protocols:
+
+        http:// or https:// → HTTP OTLP (protobuf)
+        grpc://             → gRPC (insecure)
+        grpcs://            → gRPC (TLS)
+
+    For endpoints that require authentication (e.g. AWS OSIS), pass a
+    custom exporter via the ``exporter=`` parameter:
+
+        from opensearch_genai_observability_sdk_py.exporters import AWSSigV4OTLPExporter
+
+        register(
+            exporter=AWSSigV4OTLPExporter(
+                endpoint="https://pipeline.us-east-1.osis.amazonaws.com/v1/traces",
+                service="osis",
+            )
+        )
+
+    Args:
+        endpoint: OTLP endpoint URL (full URL, used as-is). When omitted,
+            resolved from OTel env vars or the Data Prepper default.
+            Ignored if ``exporter`` is provided.
+        protocol: Force ``"http"`` or ``"grpc"``. When omitted, resolved
+            from ``OTEL_EXPORTER_OTLP_TRACES_PROTOCOL`` /
+            ``OTEL_EXPORTER_OTLP_PROTOCOL`` env vars, then inferred from
+            the URL scheme. Raises ``ValueError`` if it contradicts a
+            ``grpc://`` or ``grpcs://`` URL scheme.
+            Ignored if ``exporter`` is provided.
+        project_name: Project/service name attached to all spans.
+            Defaults to ``OTEL_SERVICE_NAME`` or ``OPENSEARCH_PROJECT``
+            env var, or ``"default"``.
+        service_name: Alias for ``project_name``.
+        batch: Use ``BatchSpanProcessor`` (``True``) or
+            ``SimpleSpanProcessor`` (``False``). Batch is recommended for
+            production.
+        auto_instrument: Discover and activate installed instrumentor
+            packages automatically.
+        exporter: Custom ``SpanExporter``. When provided,
+            ``endpoint`` / ``protocol`` / ``headers`` are ignored — the
+            exporter is used as-is. Use this to plug in authenticated
+            exporters such as ``AWSSigV4OTLPExporter``.
+        set_global: Set as the global ``TracerProvider`` (default: ``True``).
+        headers: Additional HTTP headers for the default OTLP exporter.
+            Ignored if ``exporter`` is provided.
+
+    Returns:
+        The configured ``TracerProvider``.
+
+    Raises:
+        ValueError: If ``protocol`` contradicts the URL scheme, or if an
+            unsupported protocol value is specified.
+
+    Examples:
+        # Self-hosted Data Prepper — zero config
+        register()
+
+        # OTel Collector via env var (standard OTel behaviour)
+        # OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318
+        register()
+
+        # Explicit endpoint
+        register(endpoint="http://my-collector:4318/v1/traces")
+
+        # gRPC via URL scheme
+        register(endpoint="grpc://localhost:4317")
+
+        # AWS OSIS with SigV4 signing (HTTP only)
+        from opensearch_genai_observability_sdk_py.exporters import AWSSigV4OTLPExporter
+        register(
+            exporter=AWSSigV4OTLPExporter(
+                endpoint="https://pipeline.us-east-1.osis.amazonaws.com/v1/traces",
+                service="osis",
+            )
+        )
+    """
+    resolved_endpoint = _resolve_endpoint(endpoint)
+    resolved_protocol = _resolve_protocol(protocol)
+
+    name = (
+        service_name
+        or project_name
+        or os.environ.get("OTEL_SERVICE_NAME")
+        or os.environ.get("OPENSEARCH_PROJECT", "default")
+    )
+
+    # Step 1: Create Resource (identity tag for all spans)
+    resource = Resource.create({"service.name": name})
+
+    # Step 2: Create TracerProvider
+    provider = TracerProvider(resource=resource)
+
+    # Step 3: Create Exporter
+    if exporter is None:
+        exporter = _create_exporter(
+            endpoint=resolved_endpoint,
+            protocol=resolved_protocol,
+            headers=headers,
+        )
+
+    # Step 4: Create Processor and wire up
+    processor: SpanProcessor
+    if batch:
+        processor = BatchSpanProcessor(exporter)
+    else:
+        processor = SimpleSpanProcessor(exporter)
+    provider.add_span_processor(processor)
+
+    # Step 5: Set as global provider
+    if set_global:
+        trace.set_tracer_provider(provider)
+
+    # Step 6: Auto-instrument installed libraries
+    if auto_instrument:
+        _auto_instrument(provider)
+
+    logger.info(
+        "OpenSearch AI tracing initialized: endpoint=%s project=%s",
+        resolved_endpoint,
+        name,
+    )
+
+    return provider
+
+
+def _resolve_endpoint(endpoint: str | None) -> str:
+    """Resolve the OTLP endpoint following OTel env var priority.
+
+    Priority:
+    1. ``endpoint`` argument (full URL)
+    2. ``OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`` (full URL, used as-is)
+    3. ``OTEL_EXPORTER_OTLP_ENDPOINT`` (base URL, ``/v1/traces`` appended)
+    4. Data Prepper default
+    """
+    if endpoint:
+        return endpoint
+
+    traces_ep = os.environ.get("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT")
+    if traces_ep:
+        return traces_ep
+
+    base_ep = os.environ.get("OTEL_EXPORTER_OTLP_ENDPOINT")
+    if base_ep:
+        return base_ep.rstrip("/") + "/v1/traces"
+
+    return DEFAULT_ENDPOINT
+
+
+def _resolve_protocol(protocol: str | None) -> str | None:
+    """Resolve the OTLP protocol from code param or env vars.
+
+    Returns the raw value (not yet normalised to 'http'/'grpc') so that
+    ``_infer_protocol`` can apply it together with the URL scheme.
+    Returns ``None`` if nothing is configured (infer from URL scheme).
+    """
+    if protocol is not None:
+        return protocol
+
+    return os.environ.get("OTEL_EXPORTER_OTLP_TRACES_PROTOCOL") or os.environ.get(
+        "OTEL_EXPORTER_OTLP_PROTOCOL"
+    )
+
+
+def _normalize_protocol(value: str) -> str:
+    """Map a protocol string to the internal ``'http'`` or ``'grpc'`` token.
+
+    Accepts both shorthand values (``'http'``, ``'grpc'``) and OTel spec
+    values (``'http/protobuf'``, ``'grpc'``).
+
+    Raises:
+        ValueError: For ``'http/json'`` (unsupported) or unknown values.
+    """
+    v = value.strip().lower()
+    if v == "grpc":
+        return "grpc"
+    if v in ("http", "http/protobuf"):
+        return "http"
+    if v == "http/json":
+        raise ValueError("Protocol 'http/json' is not supported. Use 'http/protobuf' or 'grpc'.")
+    raise ValueError(f"Unknown OTLP protocol '{value}'. Supported values: 'http/protobuf', 'grpc'.")
+
+
+def _infer_protocol(endpoint: str, protocol: str | None) -> str:
+    """Determine the OTLP transport protocol from explicit setting or URL scheme.
+
+    Args:
+        endpoint: The full endpoint URL.
+        protocol: Explicit protocol override (``'http'``, ``'grpc'``,
+            ``'http/protobuf'``, etc.) or ``None`` to infer from URL.
+
+    Returns:
+        ``'http'`` or ``'grpc'``.
+
+    Raises:
+        ValueError: If ``protocol`` contradicts a ``grpc://`` or ``grpcs://``
+            URL scheme, or if the protocol value is unsupported.
+    """
+    parsed = urlparse(endpoint)
+    scheme = parsed.scheme.lower()
+    url_implies_grpc = scheme in ("grpc", "grpcs")
+
+    if protocol is not None:
+        resolved = _normalize_protocol(protocol)
+        if url_implies_grpc and resolved == "http":
+            raise ValueError(
+                f"Conflicting protocol: endpoint scheme '{scheme}://' implies gRPC "
+                f"but protocol='{protocol}' was specified. "
+                f"Either use protocol='grpc' or change the endpoint scheme to "
+                f"'http://' or 'https://'."
+            )
+        return resolved
+
+    if url_implies_grpc:
+        return "grpc"
+
+    return "http"
+
+
+def _create_exporter(
+    endpoint: str,
+    protocol: str | None,
+    headers: dict | None,
+) -> SpanExporter:
+    """Create a plain OTLP exporter based on protocol and endpoint."""
+    resolved_protocol = _infer_protocol(endpoint, protocol)
+
+    if resolved_protocol == "grpc":
+        return _create_grpc_exporter(endpoint, headers)
+
+    return _create_http_exporter(endpoint, headers)
+
+
+def _create_http_exporter(
+    endpoint: str,
+    headers: dict | None,
+) -> SpanExporter:
+    """Create a plain HTTP OTLP exporter."""
+    from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+
+    return OTLPSpanExporter(endpoint=endpoint, headers=headers)
+
+
+def _create_grpc_exporter(
+    endpoint: str,
+    headers: dict | None,
+) -> SpanExporter:
+    """Create a gRPC OTLP exporter."""
+    from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import (
+        OTLPSpanExporter as GRPCSpanExporter,
+    )
+
+    parsed = urlparse(endpoint)
+    scheme = parsed.scheme.lower()
+
+    # gRPC exporter takes host:port, not a full URL
+    grpc_endpoint = parsed.netloc or endpoint
+    insecure = scheme != "grpcs" and scheme != "https"
+
+    logger.info("Using gRPC exporter: %s (insecure=%s)", grpc_endpoint, insecure)
+    return GRPCSpanExporter(
+        endpoint=grpc_endpoint,
+        insecure=insecure,
+        headers=headers,
+    )
+
+
+def _auto_instrument(provider: TracerProvider) -> None:
+    """Discover and activate installed instrumentor packages.
+
+    Searches the OpenTelemetry entry point group so instrumentors
+    from the OTel ecosystem are discovered automatically.
+    """
+    discovered = 0
+    seen_names = set()
+
+    for group in _INSTRUMENTOR_GROUPS:
+        eps = entry_points(group=group)
+
+        for ep in eps:
+            # Avoid double-instrumenting if a package registers in both groups
+            if ep.name in seen_names:
+                continue
+            seen_names.add(ep.name)
+
+            try:
+                instrumentor_cls = ep.load()
+                instrumentor = instrumentor_cls()
+                instrumentor.instrument(tracer_provider=provider)
+                discovered += 1
+                logger.debug("Instrumented: %s (from %s)", ep.name, group)
+            except Exception as exc:
+                logger.debug("Skipped instrumentor %s: %s", ep.name, exc)
+
+    if discovered == 0:
+        logger.warning(
+            "No instrumentor packages found. Install instrumentors to auto-trace "
+            "LLM calls, e.g.: pip install opentelemetry-instrumentation-openai"
+        )
+    else:
+        logger.info("Auto-instrumented %d libraries", discovered)

--- a/src/opensearch_genai_observability_sdk_py/score.py
+++ b/src/opensearch_genai_observability_sdk_py/score.py
@@ -1,0 +1,172 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+#
+# Modifications Copyright OpenSearch Contributors. See
+# GitHub history for details.
+
+"""Score submission for OpenSearch AI observability.
+
+Sends evaluation scores as OTel spans using gen_ai.evaluation.*
+semantic convention attributes.
+
+Two scoring levels:
+
+- **Span-level:** ``trace_id`` + ``span_id`` — score a specific span.
+  The score span is created as a child of that span (same trace).
+- **Trace-level:** ``trace_id`` only — score the entire trace.
+  The score span is attached to the root span of that trace.
+
+In both cases the score span joins the evaluated trace, so it appears
+alongside the execution spans in the trace waterfall.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from opentelemetry import trace
+from opentelemetry.trace import NonRecordingSpan, SpanContext, TraceFlags
+
+logger = logging.getLogger(__name__)
+
+_TRACER_NAME = "opensearch-genai-observability-sdk-py-scores"
+
+
+def score(
+    name: str,
+    value: float | None = None,
+    *,
+    trace_id: str | None = None,
+    span_id: str | None = None,
+    label: str | None = None,
+    explanation: str | None = None,
+    response_id: str | None = None,
+    source: str = "sdk",
+    metadata: dict[str, Any] | None = None,
+) -> None:
+    """Submit an evaluation score as an OTel span.
+
+    Creates a ``gen_ai.evaluation.*`` span that is attached to the
+    evaluated trace, so scores appear in the same trace waterfall as the
+    spans they evaluate.
+
+    Two scoring levels:
+
+    - **Span-level** (``trace_id`` + ``span_id``): the score span is a
+      child of the specified span.
+    - **Trace-level** (``trace_id`` only): the score span is attached to
+      the root span of the trace.
+
+    If neither ``trace_id`` nor ``span_id`` is given, a standalone score
+    span is emitted with no trace context.
+
+    Args:
+        name: Evaluation metric name (e.g., ``"relevance"``, ``"factuality"``).
+        value: Numeric score value.
+        trace_id: Hex trace ID of the trace being scored.
+        span_id: Hex span ID of the specific span being scored.
+            When omitted, the score attaches to the root span of the trace.
+        label: Human-readable label (e.g., ``"pass"``, ``"relevant"``).
+        explanation: Evaluator justification or rationale (truncated to 500 chars).
+        response_id: Completion ID for correlation with a specific LLM response.
+        source: Who created the score — ``"sdk"``, ``"human"``,
+            ``"llm-judge"``, ``"heuristic"``.
+        metadata: Optional arbitrary key-value metadata.
+
+    Examples:
+        # Span-level: score a specific span
+        score(
+            name="accuracy",
+            value=0.95,
+            trace_id="6ebb9835f43af1552f2cebb9f5165e39",
+            span_id="89829115c2128845",
+            explanation="Weather data is correct",
+            source="heuristic",
+        )
+
+        # Trace-level: score the whole trace (attaches to root span)
+        score(
+            name="relevance",
+            value=0.92,
+            trace_id="6ebb9835f43af1552f2cebb9f5165e39",
+            explanation="Response addresses the query",
+            source="llm-judge",
+        )
+    """
+    tracer = trace.get_tracer(_TRACER_NAME)
+
+    attrs: dict[str, Any] = {
+        "gen_ai.operation.name": "evaluation",
+        "gen_ai.evaluation.name": name,
+        "gen_ai.evaluation.source": source,
+    }
+
+    if value is not None:
+        attrs["gen_ai.evaluation.score.value"] = value
+    if label:
+        attrs["gen_ai.evaluation.score.label"] = label
+    if explanation:
+        attrs["gen_ai.evaluation.explanation"] = explanation[:500]
+    if response_id:
+        attrs["gen_ai.response.id"] = response_id
+    if metadata:
+        for k, v in metadata.items():
+            attrs[f"gen_ai.evaluation.metadata.{k}"] = str(v)
+
+    ctx = _build_parent_context(trace_id, span_id)
+
+    with tracer.start_as_current_span(
+        f"evaluation {name}",
+        context=ctx,
+        attributes=attrs,
+    ):
+        logger.debug("Score emitted: %s=%s (trace=%s)", name, value, trace_id)
+
+
+def _build_parent_context(
+    trace_id: str | None,
+    span_id: str | None,
+) -> Any:
+    """Build an OTel context that parents the score span to the evaluated span.
+
+    - Both provided → attach to that specific span.
+    - Only trace_id → attach to the root span (derived from trace_id).
+    - Neither → return None (standalone span, no parent context).
+    """
+    if not trace_id:
+        return None
+
+    trace_id_int = _parse_hex(trace_id)
+    if trace_id_int is None:
+        logger.warning("score(): invalid trace_id '%s', emitting standalone span", trace_id)
+        return None
+
+    # For trace-level scoring (no span_id), derive the root span_id from
+    # the lower 64 bits of the trace_id — a standard convention for root spans.
+    if span_id:
+        span_id_int = _parse_hex(span_id)
+        if span_id_int is None:
+            logger.warning("score(): invalid span_id '%s', emitting standalone span", span_id)
+            return None
+    else:
+        span_id_int = trace_id_int & 0xFFFFFFFFFFFFFFFF  # lower 64 bits
+
+    parent_span_context = SpanContext(
+        trace_id=trace_id_int,
+        span_id=span_id_int,
+        is_remote=True,
+        trace_flags=TraceFlags(TraceFlags.SAMPLED),
+    )
+    return trace.set_span_in_context(NonRecordingSpan(parent_span_context))
+
+
+def _parse_hex(value: str) -> int | None:
+    """Parse a hex string (with or without 0x prefix) to int. Returns None on failure."""
+    try:
+        return int(value.lstrip("0x").lstrip("0X") or "0", 16)
+    except ValueError:
+        return None

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+#
+# Modifications Copyright OpenSearch Contributors. See
+# GitHub history for details.
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,60 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+#
+# Modifications Copyright OpenSearch Contributors. See
+# GitHub history for details.
+
+"""Shared test fixtures for opensearch-genai-observability-sdk-py tests.
+
+Sets up a TracerProvider with InMemorySpanExporter so tests can capture
+and assert on spans without a real collector.
+
+A single TracerProvider is shared across the entire test session.
+The exporter is cleared before and after every test via the autouse
+_clear_spans fixture so tests never see each other's spans.
+
+Because the SDK decorators fetch trace.get_tracer() at call time (not at
+decoration/import time), the global provider set here is always resolved
+correctly when a decorated function is invoked — no private API hacks
+required.
+"""
+
+import pytest
+from opentelemetry import trace
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+# Module-level singletons, initialised once per process.
+_exporter = InMemorySpanExporter()
+_provider = TracerProvider(
+    resource=Resource.create({"service.name": "test-service"}),
+)
+_provider.add_span_processor(SimpleSpanProcessor(_exporter))
+trace.set_tracer_provider(_provider)
+
+
+@pytest.fixture(autouse=True)
+def _clear_spans():
+    """Clear the shared InMemorySpanExporter before and after every test.
+
+    The ``autouse=True`` ensures this runs for *every* test, even those
+    that don't request the ``exporter`` fixture explicitly.
+    """
+    _exporter.clear()
+    yield
+    _exporter.clear()
+
+
+@pytest.fixture()
+def exporter():
+    """Provide the shared InMemorySpanExporter for tests that need it.
+
+    Call ``exporter.get_finished_spans()`` after exercising the code
+    under test to inspect the captured spans.
+    """
+    return _exporter

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -1,0 +1,597 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+#
+# Modifications Copyright OpenSearch Contributors. See
+# GitHub history for details.
+
+"""Tests for opensearch_genai_observability_sdk_py.decorators.
+
+Covers @workflow, @task, @agent, @tool decorators for sync functions,
+async functions, generators, and async generators.  Verifies span
+names, semantic attributes, parent-child relationships, error handling,
+and input/output capture.
+"""
+
+import json
+
+import pytest
+from opentelemetry.trace import StatusCode
+
+from opensearch_genai_observability_sdk_py.decorators import agent, task, tool, workflow
+
+# ---------------------------------------------------------------------------
+# Helper functions decorated by the SDK
+# ---------------------------------------------------------------------------
+
+
+@workflow(name="my_workflow")
+def sync_workflow(x: int) -> int:
+    return x + 1
+
+
+@task(name="my_task")
+def sync_task(x: int) -> int:
+    return x * 2
+
+
+@agent(name="my_agent")
+def sync_agent(query: str) -> str:
+    return f"answer to {query}"
+
+
+@tool(name="my_tool")
+def sync_tool(a: int, b: int) -> int:
+    """Add two numbers."""
+    return a + b
+
+
+@workflow(name="async_workflow")
+async def async_workflow_fn(x: int) -> int:
+    return x + 10
+
+
+@task(name="async_task")
+async def async_task_fn(x: int) -> int:
+    return x * 10
+
+
+@agent(name="async_agent")
+async def async_agent_fn(query: str) -> str:
+    return f"async answer to {query}"
+
+
+@tool(name="async_tool")
+async def async_tool_fn(a: int, b: int) -> int:
+    return a + b
+
+
+@workflow(name="error_workflow")
+def error_workflow_fn():
+    raise ValueError("something went wrong")
+
+
+@workflow(name="error_async_workflow")
+async def async_error_workflow_fn():
+    raise RuntimeError("async boom")
+
+
+@workflow()
+def auto_name_workflow():
+    return "auto"
+
+
+@workflow(name="versioned_workflow", version=3)
+def versioned_workflow_fn():
+    return "v3"
+
+
+@agent(name="versioned_agent", version=2)
+def versioned_agent_fn():
+    return "v2"
+
+
+@workflow(name="parent_workflow")
+def parent_workflow_fn():
+    return child_task_fn("hello")
+
+
+@task(name="child_task")
+def child_task_fn(msg: str) -> str:
+    return msg.upper()
+
+
+@workflow(name="kwargs_workflow")
+def kwargs_workflow_fn(*, key: str, value: int) -> dict:
+    return {"key": key, "value": value}
+
+
+@workflow(name="mixed_args_workflow")
+def mixed_args_workflow_fn(a: int, b: int, *, flag: bool = False) -> str:
+    return f"{a}+{b} flag={flag}"
+
+
+@tool(name="gen_tool")
+def generator_tool_fn(n: int):
+    yield from range(n)
+
+
+@tool(name="async_gen_tool")
+async def async_generator_tool_fn(n: int):
+    for i in range(n):
+        yield i
+
+
+@tool(name="gen_error_tool")
+def generator_error_tool_fn():
+    yield 1
+    raise ValueError("gen error")
+
+
+@tool(name="async_gen_error_tool")
+async def async_generator_error_tool_fn():
+    yield 1
+    raise ValueError("async gen error")
+
+
+@tool(name="documented_tool")
+def documented_tool_fn(x: int) -> int:
+    """A tool with a docstring for testing gen_ai.tool.description."""
+    return x * 2
+
+
+@tool(name="undocumented_tool")
+def undocumented_tool_fn(x: int) -> int:
+    return x * 3
+
+
+# ---------------------------------------------------------------------------
+# Sync decorator tests
+# ---------------------------------------------------------------------------
+
+
+class TestSyncDecorators:
+    """Test sync function decorators."""
+
+    def test_workflow_creates_span(self, exporter):
+        result = sync_workflow(5)
+        assert result == 6
+
+        spans = exporter.get_finished_spans()
+        assert len(spans) == 1
+        span = spans[0]
+        assert span.name == "my_workflow"
+        assert span.attributes["gen_ai.operation.name"] == "invoke_agent"
+        assert span.attributes["gen_ai.agent.name"] == "my_workflow"
+
+    def test_task_creates_span(self, exporter):
+        result = sync_task(5)
+        assert result == 10
+
+        spans = exporter.get_finished_spans()
+        assert len(spans) == 1
+        span = spans[0]
+        assert span.name == "my_task"
+        assert span.attributes["gen_ai.operation.name"] == "invoke_agent"
+        assert span.attributes["gen_ai.agent.name"] == "my_task"
+
+    def test_agent_creates_span(self, exporter):
+        result = sync_agent("test")
+        assert result == "answer to test"
+
+        spans = exporter.get_finished_spans()
+        assert len(spans) == 1
+        span = spans[0]
+        assert span.name == "invoke_agent my_agent"
+        assert span.attributes["gen_ai.operation.name"] == "invoke_agent"
+        assert span.attributes["gen_ai.agent.name"] == "my_agent"
+
+    def test_tool_creates_span(self, exporter):
+        result = sync_tool(3, 4)
+        assert result == 7
+
+        spans = exporter.get_finished_spans()
+        assert len(spans) == 1
+        span = spans[0]
+        assert span.name == "execute_tool my_tool"
+        assert span.attributes["gen_ai.operation.name"] == "execute_tool"
+        assert span.attributes["gen_ai.tool.name"] == "my_tool"
+
+    def test_tool_type_attribute(self, exporter):
+        sync_tool(1, 2)
+        spans = exporter.get_finished_spans()
+        span = spans[0]
+        assert span.attributes["gen_ai.tool.type"] == "function"
+
+    def test_tool_description_from_docstring(self, exporter):
+        documented_tool_fn(5)
+        spans = exporter.get_finished_spans()
+        span = spans[0]
+        assert (
+            span.attributes["gen_ai.tool.description"]
+            == "A tool with a docstring for testing gen_ai.tool.description."
+        )
+
+    def test_tool_no_description_when_no_docstring(self, exporter):
+        undocumented_tool_fn(5)
+        spans = exporter.get_finished_spans()
+        span = spans[0]
+        assert "gen_ai.tool.description" not in span.attributes
+
+    def test_tool_input_uses_call_arguments(self, exporter):
+        sync_tool(3, 4)
+        spans = exporter.get_finished_spans()
+        span = spans[0]
+        captured = json.loads(span.attributes["gen_ai.tool.call.arguments"])
+        assert captured == {"a": 3, "b": 4}
+        assert "gen_ai.input.messages" not in span.attributes
+
+    def test_tool_output_uses_call_result(self, exporter):
+        result = sync_tool(3, 4)
+        assert result == 7
+        spans = exporter.get_finished_spans()
+        span = spans[0]
+        assert json.loads(span.attributes["gen_ai.tool.call.result"]) == 7
+        assert "gen_ai.output.messages" not in span.attributes
+
+    def test_input_capture_single_arg(self, exporter):
+        sync_workflow(42)
+        spans = exporter.get_finished_spans()
+        span = spans[0]
+        # Single positional arg is captured directly
+        assert json.loads(span.attributes["gen_ai.input.messages"]) == {"x": 42}
+
+    def test_input_capture_kwargs_only(self, exporter):
+        kwargs_workflow_fn(key="x", value=99)
+        spans = exporter.get_finished_spans()
+        span = spans[0]
+        captured = json.loads(span.attributes["gen_ai.input.messages"])
+        assert captured == {"key": "x", "value": 99}
+
+    def test_input_capture_mixed_args_kwargs(self, exporter):
+        mixed_args_workflow_fn(1, 2, flag=True)
+        spans = exporter.get_finished_spans()
+        span = spans[0]
+        captured = json.loads(span.attributes["gen_ai.input.messages"])
+        assert captured == {"a": 1, "b": 2, "flag": True}
+
+    def test_output_capture(self, exporter):
+        result = sync_workflow(5)
+        assert result == 6
+        spans = exporter.get_finished_spans()
+        span = spans[0]
+        assert json.loads(span.attributes["gen_ai.output.messages"]) == 6
+
+    def test_output_capture_dict(self, exporter):
+        result = kwargs_workflow_fn(key="x", value=99)
+        assert result == {"key": "x", "value": 99}
+        spans = exporter.get_finished_spans()
+        span = spans[0]
+        captured = json.loads(span.attributes["gen_ai.output.messages"])
+        assert captured == {"key": "x", "value": 99}
+
+    def test_error_sets_span_status(self, exporter):
+        with pytest.raises(ValueError, match="something went wrong"):
+            error_workflow_fn()
+
+        spans = exporter.get_finished_spans()
+        assert len(spans) == 1
+        span = spans[0]
+        assert span.status.status_code == StatusCode.ERROR
+        assert "something went wrong" in span.status.description
+
+    def test_error_records_exception_event(self, exporter):
+        with pytest.raises(ValueError):
+            error_workflow_fn()
+
+        spans = exporter.get_finished_spans()
+        span = spans[0]
+        events = span.events
+        exc_events = [e for e in events if e.name == "exception"]
+        assert len(exc_events) >= 1
+        assert "ValueError" in exc_events[0].attributes["exception.type"]
+
+    def test_auto_name_uses_qualname(self, exporter):
+        auto_name_workflow()
+        spans = exporter.get_finished_spans()
+        span = spans[0]
+        assert span.name == "auto_name_workflow"
+
+    def test_version_attribute_workflow(self, exporter):
+        versioned_workflow_fn()
+        spans = exporter.get_finished_spans()
+        span = spans[0]
+        assert span.attributes["gen_ai.agent.version"] == "3"
+
+    def test_no_version_attribute_when_not_set(self, exporter):
+        sync_workflow(1)
+        spans = exporter.get_finished_spans()
+        span = spans[0]
+        assert "gen_ai.agent.version" not in span.attributes
+
+
+class TestParentChildRelationships:
+    """Test that nested decorated functions produce correct parent-child spans."""
+
+    def test_nested_workflow_task(self, exporter):
+        result = parent_workflow_fn()
+        assert result == "HELLO"
+
+        spans = exporter.get_finished_spans()
+        assert len(spans) == 2
+
+        # Spans are finished in order: child first, then parent
+        child_span = next(s for s in spans if s.name == "child_task")
+        parent_span = next(s for s in spans if s.name == "parent_workflow")
+
+        # Both belong to the same trace
+        assert child_span.context.trace_id == parent_span.context.trace_id
+
+        # Child's parent is the workflow span
+        assert child_span.parent.span_id == parent_span.context.span_id
+
+
+# ---------------------------------------------------------------------------
+# Async decorator tests
+# ---------------------------------------------------------------------------
+
+
+class TestAsyncDecorators:
+    """Test async function decorators."""
+
+    @pytest.mark.asyncio
+    async def test_async_workflow(self, exporter):
+        result = await async_workflow_fn(5)
+        assert result == 15
+
+        spans = exporter.get_finished_spans()
+        assert len(spans) == 1
+        span = spans[0]
+        assert span.name == "async_workflow"
+        assert span.attributes["gen_ai.operation.name"] == "invoke_agent"
+
+    @pytest.mark.asyncio
+    async def test_async_agent(self, exporter):
+        result = await async_agent_fn("hello")
+        assert result == "async answer to hello"
+
+        spans = exporter.get_finished_spans()
+        assert len(spans) == 1
+        span = spans[0]
+        assert span.name == "invoke_agent async_agent"
+        assert span.attributes["gen_ai.operation.name"] == "invoke_agent"
+
+    @pytest.mark.asyncio
+    async def test_async_tool(self, exporter):
+        result = await async_tool_fn(10, 20)
+        assert result == 30
+
+        spans = exporter.get_finished_spans()
+        assert len(spans) == 1
+        span = spans[0]
+        assert span.name == "execute_tool async_tool"
+        assert span.attributes["gen_ai.operation.name"] == "execute_tool"
+
+    @pytest.mark.asyncio
+    async def test_async_output_capture(self, exporter):
+        result = await async_workflow_fn(7)
+        assert result == 17
+
+        spans = exporter.get_finished_spans()
+        span = spans[0]
+        assert json.loads(span.attributes["gen_ai.output.messages"]) == 17
+
+    @pytest.mark.asyncio
+    async def test_async_input_capture(self, exporter):
+        await async_tool_fn(10, 20)
+        spans = exporter.get_finished_spans()
+        span = spans[0]
+        captured = json.loads(span.attributes["gen_ai.tool.call.arguments"])
+        assert captured == {"a": 10, "b": 20}
+
+    @pytest.mark.asyncio
+    async def test_async_error_sets_span_status(self, exporter):
+        with pytest.raises(RuntimeError, match="async boom"):
+            await async_error_workflow_fn()
+
+        spans = exporter.get_finished_spans()
+        assert len(spans) == 1
+        span = spans[0]
+        assert span.status.status_code == StatusCode.ERROR
+        assert "async boom" in span.status.description
+
+
+# ---------------------------------------------------------------------------
+# Generator decorator tests
+# ---------------------------------------------------------------------------
+
+
+class TestGeneratorDecorators:
+    """Test generator and async generator function decorators."""
+
+    def test_sync_generator(self, exporter):
+        items = list(generator_tool_fn(3))
+        assert items == [0, 1, 2]
+
+        spans = exporter.get_finished_spans()
+        assert len(spans) == 1
+        span = spans[0]
+        assert span.name == "execute_tool gen_tool"
+        assert span.attributes["gen_ai.operation.name"] == "execute_tool"
+
+    @pytest.mark.asyncio
+    async def test_async_generator(self, exporter):
+        items = []
+        async for item in async_generator_tool_fn(3):
+            items.append(item)
+        assert items == [0, 1, 2]
+
+        spans = exporter.get_finished_spans()
+        assert len(spans) == 1
+        span = spans[0]
+        assert span.name == "execute_tool async_gen_tool"
+        assert span.attributes["gen_ai.operation.name"] == "execute_tool"
+
+    def test_sync_generator_output_captured(self, exporter):
+        items = list(generator_tool_fn(3))
+        assert items == [0, 1, 2]
+        span = exporter.get_finished_spans()[0]
+        import json
+
+        assert json.loads(span.attributes["gen_ai.tool.call.result"]) == [0, 1, 2]
+
+    @pytest.mark.asyncio
+    async def test_async_generator_output_captured(self, exporter):
+        items = []
+        async for item in async_generator_tool_fn(3):
+            items.append(item)
+        assert items == [0, 1, 2]
+        span = exporter.get_finished_spans()[0]
+        import json
+
+        assert json.loads(span.attributes["gen_ai.tool.call.result"]) == [0, 1, 2]
+
+    def test_sync_generator_error(self, exporter):
+        gen = generator_error_tool_fn()
+        assert next(gen) == 1
+        with pytest.raises(ValueError, match="gen error"):
+            next(gen)
+
+        spans = exporter.get_finished_spans()
+        assert len(spans) == 1
+        span = spans[0]
+        assert span.status.status_code == StatusCode.ERROR
+
+    @pytest.mark.asyncio
+    async def test_async_generator_error(self, exporter):
+        agen = async_generator_error_tool_fn()
+        first = await agen.__anext__()
+        assert first == 1
+        with pytest.raises(ValueError, match="async gen error"):
+            await agen.__anext__()
+
+        spans = exporter.get_finished_spans()
+        assert len(spans) == 1
+        span = spans[0]
+        assert span.status.status_code == StatusCode.ERROR
+
+
+# ---------------------------------------------------------------------------
+# functools.wraps preservation
+# ---------------------------------------------------------------------------
+
+
+class TestFunctoolsWraps:
+    """Verify that decorators preserve the original function metadata."""
+
+    def test_sync_preserves_name(self):
+        assert sync_workflow.__name__ == "sync_workflow"
+
+    def test_async_preserves_name(self):
+        assert async_workflow_fn.__name__ == "async_workflow_fn"
+
+    def test_generator_preserves_name(self):
+        assert generator_tool_fn.__name__ == "generator_tool_fn"
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    """Test edge cases for decorators."""
+
+    def test_none_return_no_output_attribute(self, exporter):
+        @workflow(name="none_return")
+        def returns_none():
+            return None
+
+        returns_none()
+        spans = exporter.get_finished_spans()
+        span = spans[0]
+        # _set_output skips None results
+        assert "gen_ai.output.messages" not in span.attributes
+
+    def test_no_args_no_input_attribute(self, exporter):
+        @workflow(name="no_args")
+        def no_args_fn():
+            return 42
+
+        no_args_fn()
+        spans = exporter.get_finished_spans()
+        span = spans[0]
+        # _set_input skips when no args and no kwargs
+        assert "gen_ai.input.messages" not in span.attributes
+
+    def test_large_input_is_truncated(self, exporter):
+        @workflow(name="big_input")
+        def big_input_fn(data: str) -> str:
+            return "ok"
+
+        big_data = "x" * 20_000
+        big_input_fn(big_data)
+        spans = exporter.get_finished_spans()
+        span = spans[0]
+        captured = span.attributes["gen_ai.input.messages"]
+        assert len(captured) <= 10_100  # 10000 + truncation marker + quotes
+        assert "truncated" in captured
+
+    def test_large_output_is_truncated(self, exporter):
+        @workflow(name="big_output")
+        def big_output_fn() -> str:
+            return "y" * 20_000
+
+        big_output_fn()
+        spans = exporter.get_finished_spans()
+        span = spans[0]
+        captured = span.attributes["gen_ai.output.messages"]
+        assert len(captured) <= 10_100
+        assert "truncated" in captured
+
+    def test_non_serializable_input_does_not_crash(self, exporter):
+        @workflow(name="non_serial_input")
+        def non_serial_fn(obj):
+            return "ok"
+
+        # A custom object with no JSON serialization -- default=str handles it
+        class Weird:
+            pass
+
+        non_serial_fn(Weird())
+        spans = exporter.get_finished_spans()
+        assert len(spans) == 1  # Decorator should not crash
+
+    def test_non_serializable_output_does_not_crash(self, exporter):
+        @workflow(name="non_serial_output")
+        def returns_weird():
+            class Weird:
+                pass
+
+            return Weird()
+
+        returns_weird()
+        spans = exporter.get_finished_spans()
+        assert len(spans) == 1  # Decorator should not crash
+
+    def test_tool_none_return_no_output_attribute(self, exporter):
+        @tool(name="none_tool")
+        def tool_returns_none():
+            return None
+
+        tool_returns_none()
+        spans = exporter.get_finished_spans()
+        span = spans[0]
+        assert "gen_ai.tool.call.result" not in span.attributes
+
+    def test_tool_no_args_no_input_attribute(self, exporter):
+        @tool(name="no_args_tool")
+        def tool_no_args():
+            return 42
+
+        tool_no_args()
+        spans = exporter.get_finished_spans()
+        span = spans[0]
+        assert "gen_ai.tool.call.arguments" not in span.attributes

--- a/tests/test_exporters.py
+++ b/tests/test_exporters.py
@@ -1,0 +1,258 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+#
+# Modifications Copyright OpenSearch Contributors. See
+# GitHub history for details.
+
+"""Tests for opensearch_genai_observability_sdk_py.exporters.
+
+Covers _SigV4AuthSession (header injection and body-hash correctness)
+and AWSSigV4OTLPExporter (initialization guards).
+No real AWS credentials or network calls are made."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import botocore.auth
+import pytest
+from botocore.awsrequest import AWSRequest
+from botocore.credentials import Credentials
+
+from opensearch_genai_observability_sdk_py.exporters import AWSSigV4OTLPExporter, _SigV4AuthSession
+
+# ---------------------------------------------------------------------------
+# Shared test fixtures
+# ---------------------------------------------------------------------------
+
+ENDPOINT = "https://pipeline.us-east-1.osis.amazonaws.com/v1/traces"
+REGION = "us-east-1"
+SERVICE = "osis"
+
+# Static credentials — never touch real AWS.
+FAKE_CREDS = Credentials(
+    access_key="AKIAIOSFODNN7EXAMPLE",
+    secret_key="wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",  # noqa: S106
+    token="FakeSessionToken",  # noqa: S106
+)
+
+FAKE_CREDS_NO_TOKEN = Credentials(
+    access_key="AKIAIOSFODNN7EXAMPLE",
+    secret_key="wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",  # noqa: S106
+)
+
+
+def _make_session(credentials=FAKE_CREDS) -> _SigV4AuthSession:
+    return _SigV4AuthSession(credentials, service=SERVICE, region=REGION)
+
+
+# ---------------------------------------------------------------------------
+# _SigV4AuthSession — header injection
+# ---------------------------------------------------------------------------
+
+
+class TestSigV4AuthSessionHeaders:
+    """Verify that SigV4 auth headers are injected into outgoing requests."""
+
+    @patch("requests.Session.request")
+    def test_authorization_header_present(self, mock_request):
+        mock_request.return_value = MagicMock(status_code=200)
+        _make_session().request("POST", ENDPOINT, data=b"some-proto-bytes")
+
+        headers = mock_request.call_args.kwargs["headers"]
+        assert "Authorization" in headers
+
+    @patch("requests.Session.request")
+    def test_x_amz_date_header_present(self, mock_request):
+        mock_request.return_value = MagicMock(status_code=200)
+        _make_session().request("POST", ENDPOINT, data=b"payload")
+
+        headers = mock_request.call_args.kwargs["headers"]
+        assert "X-Amz-Date" in headers
+
+    @patch("requests.Session.request")
+    def test_security_token_injected_for_temp_credentials(self, mock_request):
+        """X-Amz-Security-Token must be present when using temporary credentials."""
+        mock_request.return_value = MagicMock(status_code=200)
+        _make_session(FAKE_CREDS).request("POST", ENDPOINT, data=b"payload")
+
+        headers = mock_request.call_args.kwargs["headers"]
+        assert "X-Amz-Security-Token" in headers
+        assert headers["X-Amz-Security-Token"] == "FakeSessionToken"
+
+    @patch("requests.Session.request")
+    def test_no_security_token_for_long_term_credentials(self, mock_request):
+        """X-Amz-Security-Token must not appear for long-term (non-STS) credentials."""
+        mock_request.return_value = MagicMock(status_code=200)
+        _make_session(FAKE_CREDS_NO_TOKEN).request("POST", ENDPOINT, data=b"payload")
+
+        headers = mock_request.call_args.kwargs["headers"]
+        assert "X-Amz-Security-Token" not in headers
+
+    @patch("requests.Session.request")
+    def test_existing_headers_are_preserved(self, mock_request):
+        """Headers passed by the caller (e.g. Content-Type) survive signing."""
+        mock_request.return_value = MagicMock(status_code=200)
+        incoming_headers = {"Content-Type": "application/x-protobuf", "X-Custom": "value"}
+        _make_session().request("POST", ENDPOINT, data=b"payload", headers=incoming_headers)
+
+        headers = mock_request.call_args.kwargs["headers"]
+        assert headers.get("X-Custom") == "value"
+        # SigV4 headers are added on top
+        assert "Authorization" in headers
+
+    @patch("requests.Session.request")
+    def test_none_headers_treated_as_empty(self, mock_request):
+        """Passing headers=None should not crash — auth headers are still injected."""
+        mock_request.return_value = MagicMock(status_code=200)
+        _make_session().request("POST", ENDPOINT, data=b"payload", headers=None)
+
+        headers = mock_request.call_args.kwargs["headers"]
+        assert "Authorization" in headers
+
+    @patch("requests.Session.request")
+    def test_real_data_forwarded_to_parent(self, mock_request):
+        """The real payload must be forwarded to requests.Session.request unchanged."""
+        mock_request.return_value = MagicMock(status_code=200)
+        payload = b"this-is-real-protobuf"
+        _make_session().request("POST", ENDPOINT, data=payload)
+
+        assert mock_request.call_args.kwargs["data"] == payload
+
+
+# ---------------------------------------------------------------------------
+# _SigV4AuthSession — body hash correctness (regression for empty-body bug)
+# ---------------------------------------------------------------------------
+
+
+class TestSigV4BodyHash:
+    """
+    Verify that the signature is computed over the *real* request body,
+    not a placeholder empty string.
+
+    AWS SigV4 includes SHA256(body) in the canonical request.  If the
+    SDK signed over b"" while sending a non-empty protobuf payload, AWS
+    would compute a different body hash and return 403 SignatureDoesNotMatch.
+
+    These tests confirm that different bodies produce different signatures,
+    which is only possible if the body is actually hashed.
+    """
+
+    def _capture_auth_header(self, mock_request, data: bytes) -> str:
+        mock_request.reset_mock()
+        mock_request.return_value = MagicMock(status_code=200)
+        _make_session().request("POST", ENDPOINT, data=data)
+        return mock_request.call_args.kwargs["headers"]["Authorization"]
+
+    @patch("requests.Session.request")
+    def test_different_bodies_produce_different_signatures(self, mock_request):
+        """Core regression: body hash must reflect the real payload."""
+        sig_a = self._capture_auth_header(mock_request, b"body-variant-alpha")
+        sig_b = self._capture_auth_header(mock_request, b"body-variant-beta")
+        assert sig_a != sig_b, "Different bodies must produce different SigV4 signatures"
+
+    @patch("requests.Session.request")
+    def test_empty_body_signature_differs_from_real_body(self, mock_request):
+        """
+        Regression test for the original bug.
+
+        The old implementation signed over data=b"" unconditionally, so
+        the Authorization header always contained the empty-body hash
+        regardless of the actual OTLP payload.  This test fails with the
+        old approach and passes with the fixed one.
+        """
+        sig_empty = self._capture_auth_header(mock_request, b"")
+        sig_real = self._capture_auth_header(mock_request, b"real-otlp-protobuf-payload")
+        assert sig_empty != sig_real, (
+            "Signing over an empty body must produce a different signature than signing "
+            "over the real protobuf body.  If they are equal the body hash is not being "
+            "computed correctly (likely the old empty-body-hash bug)."
+        )
+
+    @patch("requests.Session.request")
+    def test_none_data_treated_as_empty_body(self, mock_request):
+        """data=None must not crash — treated the same as b''."""
+        mock_request.return_value = MagicMock(status_code=200)
+        _make_session().request("POST", ENDPOINT, data=None)
+        headers = mock_request.call_args.kwargs["headers"]
+        assert "Authorization" in headers
+
+
+# ---------------------------------------------------------------------------
+# AWSSigV4OTLPExporter — initialization guards
+# ---------------------------------------------------------------------------
+
+
+class TestAWSSigV4OTLPExporterInit:
+    """Verify initialization errors and correct session wiring."""
+
+    def _mock_botocore(self, credentials=FAKE_CREDS, region: str | None = "us-east-1"):
+        """Return a context manager that patches botocore.session.get_session()."""
+        mock_session = MagicMock()
+        mock_session.get_credentials.return_value = credentials
+        mock_session.get_config_variable.return_value = region
+
+        return patch("botocore.session.get_session", return_value=mock_session)
+
+    def test_raises_if_no_credentials(self):
+        with self._mock_botocore(credentials=None):
+            with pytest.raises(RuntimeError, match="No AWS credentials found"):
+                AWSSigV4OTLPExporter(endpoint=ENDPOINT, region=REGION)
+
+    def test_raises_if_no_region(self):
+        with self._mock_botocore(region=None):
+            with pytest.raises(RuntimeError, match="No AWS region found"):
+                AWSSigV4OTLPExporter(endpoint=ENDPOINT)
+
+    def test_explicit_region_overrides_botocore(self):
+        """region= kwarg takes precedence over whatever botocore detects."""
+        with self._mock_botocore(region="ap-southeast-1"):
+            exporter = AWSSigV4OTLPExporter(endpoint=ENDPOINT, region="eu-west-1")
+        assert exporter._session._region == "eu-west-1"
+
+    def test_session_is_sigv4_auth_session(self):
+        """The exporter's internal session must be our signing session."""
+        with self._mock_botocore():
+            exporter = AWSSigV4OTLPExporter(endpoint=ENDPOINT)
+        assert isinstance(exporter._session, _SigV4AuthSession)
+
+    def test_session_carries_correct_service(self):
+        with self._mock_botocore():
+            exporter = AWSSigV4OTLPExporter(endpoint=ENDPOINT, service="es")
+        assert exporter._session._service == "es"
+
+    def test_default_service_is_osis(self):
+        with self._mock_botocore():
+            exporter = AWSSigV4OTLPExporter(endpoint=ENDPOINT)
+        assert exporter._session._service == "osis"
+
+
+# ---------------------------------------------------------------------------
+# Canonical request structure — independent mathematical verification
+# ---------------------------------------------------------------------------
+
+
+class TestSigV4CanonicalRequest:
+    """Verify that our code passes the real body to botocore."""
+
+    @patch("requests.Session.request")
+    def test_add_auth_receives_real_body_not_placeholder(self, mock_request):
+        """_SigV4AuthSession must pass the real payload to SigV4Auth.add_auth(), not b''."""
+        mock_request.return_value = MagicMock(status_code=200)
+        payload = b"protobuf-spans-for-real"
+        captured: list[AWSRequest] = []
+
+        original_add_auth = botocore.auth.SigV4Auth.add_auth
+
+        def intercepting_add_auth(self, request):
+            captured.append(request)
+            return original_add_auth(self, request)
+
+        with patch.object(botocore.auth.SigV4Auth, "add_auth", intercepting_add_auth):
+            _make_session().request("POST", ENDPOINT, data=payload)
+
+        assert len(captured) == 1
+        assert captured[0].body == payload

--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -1,0 +1,232 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+#
+# Modifications Copyright OpenSearch Contributors. See
+# GitHub history for details.
+
+"""Tests for opensearch_genai_observability_sdk_py.register."""
+
+import importlib
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from opensearch_genai_observability_sdk_py.register import _infer_protocol, _resolve_endpoint
+
+# importlib.import_module is needed because opensearch_genai_observability_sdk_py.__init__ imports
+# `register` (the function) into the package namespace, shadowing the submodule name.
+# Using importlib bypasses that and returns the actual module object.
+_register_mod = importlib.import_module("opensearch_genai_observability_sdk_py.register")
+
+
+# ---------------------------------------------------------------------------
+# _infer_protocol
+# ---------------------------------------------------------------------------
+
+
+class TestInferProtocol:
+    """Unit tests for protocol inference and validation."""
+
+    def test_http_scheme(self):
+        assert _infer_protocol("http://localhost:4318/v1/traces", None) == "http"
+
+    def test_https_scheme(self):
+        assert _infer_protocol("https://collector.example.com/v1/traces", None) == "http"
+
+    def test_grpc_scheme(self):
+        assert _infer_protocol("grpc://localhost:4317", None) == "grpc"
+
+    def test_grpcs_scheme(self):
+        assert _infer_protocol("grpcs://collector.example.com:4317", None) == "grpc"
+
+    def test_explicit_grpc_overrides_http_scheme(self):
+        """http:// is ambiguous — explicit grpc wins."""
+        assert _infer_protocol("http://localhost:4317", "grpc") == "grpc"
+
+    def test_explicit_http_protobuf_accepted(self):
+        assert _infer_protocol("http://localhost:4318/v1/traces", "http/protobuf") == "http"
+
+    def test_contradicting_http_on_grpc_scheme_raises(self):
+        """grpc:// unambiguously means gRPC — contradicting it is an error."""
+        with pytest.raises(ValueError, match="Conflicting protocol"):
+            _infer_protocol("grpc://localhost:4317", "http")
+
+    def test_contradicting_http_protobuf_on_grpcs_scheme_raises(self):
+        with pytest.raises(ValueError, match="Conflicting protocol"):
+            _infer_protocol("grpcs://localhost:4317", "http/protobuf")
+
+    def test_http_json_raises(self):
+        with pytest.raises(ValueError, match="http/json.*not supported"):
+            _infer_protocol("http://localhost:4318/v1/traces", "http/json")
+
+    def test_unknown_protocol_raises(self):
+        with pytest.raises(ValueError, match="Unknown OTLP protocol"):
+            _infer_protocol("http://localhost:4318/v1/traces", "thrift")
+
+
+# ---------------------------------------------------------------------------
+# _resolve_endpoint
+# ---------------------------------------------------------------------------
+
+
+class TestResolveEndpoint:
+    """Unit tests for endpoint resolution priority."""
+
+    def test_code_endpoint_wins(self, monkeypatch):
+        monkeypatch.setenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "http://traces:4318/v1/traces")
+        monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://base:4318")
+        assert (
+            _resolve_endpoint("http://explicit:4318/v1/traces") == "http://explicit:4318/v1/traces"
+        )
+
+    def test_traces_endpoint_env_var(self, monkeypatch):
+        monkeypatch.setenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "http://traces:4318/v1/traces")
+        assert _resolve_endpoint(None) == "http://traces:4318/v1/traces"
+
+    def test_base_endpoint_env_var_appends_path(self, monkeypatch):
+        monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4318")
+        assert _resolve_endpoint(None) == "http://localhost:4318/v1/traces"
+
+    def test_base_endpoint_trailing_slash_handled(self, monkeypatch):
+        monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4318/")
+        assert _resolve_endpoint(None) == "http://localhost:4318/v1/traces"
+
+    def test_traces_endpoint_takes_priority_over_base(self, monkeypatch):
+        monkeypatch.setenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "http://traces:4318/v1/traces")
+        monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://base:4318")
+        assert _resolve_endpoint(None) == "http://traces:4318/v1/traces"
+
+    def test_data_prepper_default(self, monkeypatch):
+        monkeypatch.delenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", raising=False)
+        monkeypatch.delenv("OTEL_EXPORTER_OTLP_ENDPOINT", raising=False)
+        assert _resolve_endpoint(None) == _register_mod.DEFAULT_ENDPOINT
+
+
+# ---------------------------------------------------------------------------
+# register()
+# ---------------------------------------------------------------------------
+
+
+class TestRegister:
+    """Tests for the register() function."""
+
+    @patch.object(_register_mod, "_create_http_exporter")
+    def test_register_returns_tracer_provider(self, mock_create_http):
+        from opentelemetry.sdk.trace import TracerProvider
+
+        from opensearch_genai_observability_sdk_py.register import register
+
+        mock_create_http.return_value = MagicMock()
+        provider = register(set_global=False, auto_instrument=False)
+        assert isinstance(provider, TracerProvider)
+
+    @patch.object(_register_mod, "_create_http_exporter")
+    def test_register_uses_default_endpoint(self, mock_create_http, monkeypatch):
+        from opensearch_genai_observability_sdk_py.register import (
+            DEFAULT_ENDPOINT,
+            register,
+        )
+
+        monkeypatch.delenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", raising=False)
+        monkeypatch.delenv("OTEL_EXPORTER_OTLP_ENDPOINT", raising=False)
+        mock_create_http.return_value = MagicMock()
+        register(set_global=False, auto_instrument=False)
+        mock_create_http.assert_called_once_with(DEFAULT_ENDPOINT, None)
+
+    @patch.object(_register_mod, "_create_http_exporter")
+    def test_register_uses_provided_endpoint(self, mock_create_http):
+        from opensearch_genai_observability_sdk_py.register import register
+
+        mock_create_http.return_value = MagicMock()
+        register(
+            endpoint="http://my-collector:4318/v1/traces",
+            set_global=False,
+            auto_instrument=False,
+        )
+        mock_create_http.assert_called_once_with("http://my-collector:4318/v1/traces", None)
+
+    @patch.object(_register_mod, "_create_http_exporter")
+    def test_register_uses_otel_traces_endpoint_env_var(self, mock_create_http, monkeypatch):
+        from opensearch_genai_observability_sdk_py.register import register
+
+        monkeypatch.setenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "http://otel:4318/v1/traces")
+        monkeypatch.delenv("OTEL_EXPORTER_OTLP_ENDPOINT", raising=False)
+        mock_create_http.return_value = MagicMock()
+        register(set_global=False, auto_instrument=False)
+        mock_create_http.assert_called_once_with("http://otel:4318/v1/traces", None)
+
+    @patch.object(_register_mod, "_create_http_exporter")
+    def test_register_uses_otel_base_endpoint_env_var(self, mock_create_http, monkeypatch):
+        from opensearch_genai_observability_sdk_py.register import register
+
+        monkeypatch.delenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", raising=False)
+        monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4318")
+        mock_create_http.return_value = MagicMock()
+        register(set_global=False, auto_instrument=False)
+        mock_create_http.assert_called_once_with("http://localhost:4318/v1/traces", None)
+
+    @patch.object(_register_mod, "_create_grpc_exporter")
+    def test_register_uses_grpc_for_grpc_scheme(self, mock_create_grpc):
+        from opensearch_genai_observability_sdk_py.register import register
+
+        mock_create_grpc.return_value = MagicMock()
+        register(
+            endpoint="grpc://localhost:4317",
+            set_global=False,
+            auto_instrument=False,
+        )
+        mock_create_grpc.assert_called_once()
+
+    @patch.object(_register_mod, "_create_grpc_exporter")
+    def test_register_uses_grpc_via_protocol_env_var(self, mock_create_grpc, monkeypatch):
+        from opensearch_genai_observability_sdk_py.register import register
+
+        monkeypatch.setenv("OTEL_EXPORTER_OTLP_PROTOCOL", "grpc")
+        monkeypatch.delenv("OTEL_EXPORTER_OTLP_TRACES_PROTOCOL", raising=False)
+        mock_create_grpc.return_value = MagicMock()
+        register(
+            endpoint="http://localhost:4317",
+            set_global=False,
+            auto_instrument=False,
+        )
+        mock_create_grpc.assert_called_once()
+
+    @patch.object(_register_mod, "_create_grpc_exporter")
+    def test_register_traces_protocol_env_var_takes_priority(self, mock_create_grpc, monkeypatch):
+        from opensearch_genai_observability_sdk_py.register import register
+
+        monkeypatch.setenv("OTEL_EXPORTER_OTLP_TRACES_PROTOCOL", "grpc")
+        monkeypatch.setenv("OTEL_EXPORTER_OTLP_PROTOCOL", "http/protobuf")
+        mock_create_grpc.return_value = MagicMock()
+        register(
+            endpoint="http://localhost:4317",
+            set_global=False,
+            auto_instrument=False,
+        )
+        mock_create_grpc.assert_called_once()
+
+    def test_register_uses_custom_exporter(self):
+        from opensearch_genai_observability_sdk_py.register import register
+
+        custom_exporter = MagicMock()
+        register(exporter=custom_exporter, set_global=False, auto_instrument=False)
+        custom_exporter.export.assert_not_called()  # accepted but not called
+
+    @patch.object(_register_mod, "_create_http_exporter")
+    def test_register_passes_headers(self, mock_create_http, monkeypatch):
+        from opensearch_genai_observability_sdk_py.register import register
+
+        monkeypatch.delenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", raising=False)
+        monkeypatch.delenv("OTEL_EXPORTER_OTLP_ENDPOINT", raising=False)
+        mock_create_http.return_value = MagicMock()
+        register(
+            headers={"X-Custom": "value"},
+            set_global=False,
+            auto_instrument=False,
+        )
+        mock_create_http.assert_called_once_with(
+            _register_mod.DEFAULT_ENDPOINT, {"X-Custom": "value"}
+        )

--- a/tests/test_score.py
+++ b/tests/test_score.py
@@ -1,0 +1,232 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+#
+# Modifications Copyright OpenSearch Contributors. See
+# GitHub history for details.
+
+"""Tests for opensearch_genai_observability_sdk_py.score."""
+
+from opensearch_genai_observability_sdk_py.score import _parse_hex, score
+
+TRACE_ID = "6ebb9835f43af1552f2cebb9f5165e39"
+SPAN_ID = "89829115c2128845"
+
+
+# ---------------------------------------------------------------------------
+# Span name and gen_ai.operation.name
+# ---------------------------------------------------------------------------
+
+
+class TestSpanStructure:
+    def test_span_name_includes_metric_name(self, exporter):
+        score(name="relevance", value=0.9)
+        span = exporter.get_finished_spans()[0]
+        assert span.name == "evaluation relevance"
+
+    def test_operation_name_is_evaluation(self, exporter):
+        score(name="accuracy", value=0.8)
+        span = exporter.get_finished_spans()[0]
+        assert span.attributes["gen_ai.operation.name"] == "evaluation"
+
+    def test_evaluation_name_attribute(self, exporter):
+        score(name="factuality", value=0.7)
+        span = exporter.get_finished_spans()[0]
+        assert span.attributes["gen_ai.evaluation.name"] == "factuality"
+
+
+# ---------------------------------------------------------------------------
+# Span-level scoring — score span is a child of the evaluated span
+# ---------------------------------------------------------------------------
+
+
+class TestSpanLevelScoring:
+    def test_score_span_joins_evaluated_trace(self, exporter):
+        score(name="accuracy", value=0.95, trace_id=TRACE_ID, span_id=SPAN_ID)
+
+        span = exporter.get_finished_spans()[0]
+        assert format(span.context.trace_id, "032x") == TRACE_ID
+
+    def test_score_span_parent_is_evaluated_span(self, exporter):
+        score(name="accuracy", value=0.95, trace_id=TRACE_ID, span_id=SPAN_ID)
+
+        span = exporter.get_finished_spans()[0]
+        assert format(span.parent.span_id, "016x") == SPAN_ID
+
+    def test_score_value(self, exporter):
+        score(name="accuracy", value=0.95, trace_id=TRACE_ID, span_id=SPAN_ID)
+        span = exporter.get_finished_spans()[0]
+        assert span.attributes["gen_ai.evaluation.score.value"] == 0.95
+
+    def test_no_string_trace_id_attribute(self, exporter):
+        """trace_id is encoded in the span context, not duplicated as an attribute."""
+        score(name="accuracy", value=0.95, trace_id=TRACE_ID, span_id=SPAN_ID)
+        span = exporter.get_finished_spans()[0]
+        assert "gen_ai.evaluation.trace_id" not in span.attributes
+        assert "gen_ai.evaluation.span_id" not in span.attributes
+
+
+# ---------------------------------------------------------------------------
+# Trace-level scoring — score span attaches to root span of the trace
+# ---------------------------------------------------------------------------
+
+
+class TestTraceLevelScoring:
+    def test_score_span_joins_evaluated_trace(self, exporter):
+        score(name="relevance", value=0.92, trace_id=TRACE_ID)
+
+        span = exporter.get_finished_spans()[0]
+        assert format(span.context.trace_id, "032x") == TRACE_ID
+
+    def test_parent_is_derived_from_trace_id(self, exporter):
+        """Root span_id = lower 64 bits of trace_id."""
+        score(name="relevance", value=0.92, trace_id=TRACE_ID)
+
+        span = exporter.get_finished_spans()[0]
+        expected_span_id = int(TRACE_ID, 16) & 0xFFFFFFFFFFFFFFFF
+        assert span.parent.span_id == expected_span_id
+
+
+# ---------------------------------------------------------------------------
+# Standalone score (no trace context)
+# ---------------------------------------------------------------------------
+
+
+class TestStandaloneScore:
+    def test_no_trace_id_emits_root_span(self, exporter):
+        score(name="test", value=0.5)
+        span = exporter.get_finished_spans()[0]
+        assert span.parent is None
+
+    def test_invalid_trace_id_emits_standalone(self, exporter):
+        score(name="test", value=0.5, trace_id="not-hex!")
+        span = exporter.get_finished_spans()[0]
+        assert span.parent is None
+
+    def test_invalid_span_id_emits_standalone(self, exporter):
+        score(name="test", value=0.5, trace_id=TRACE_ID, span_id="not-hex!")
+        span = exporter.get_finished_spans()[0]
+        assert span.parent is None
+
+
+# ---------------------------------------------------------------------------
+# Score attributes
+# ---------------------------------------------------------------------------
+
+
+class TestScoreAttributes:
+    def test_score_value(self, exporter):
+        score(name="test", value=0.95)
+        span = exporter.get_finished_spans()[0]
+        assert span.attributes["gen_ai.evaluation.score.value"] == 0.95
+
+    def test_zero_value(self, exporter):
+        score(name="toxicity", value=0.0)
+        span = exporter.get_finished_spans()[0]
+        assert span.attributes["gen_ai.evaluation.score.value"] == 0.0
+
+    def test_no_value(self, exporter):
+        score(name="test")
+        span = exporter.get_finished_spans()[0]
+        assert "gen_ai.evaluation.score.value" not in span.attributes
+
+    def test_label(self, exporter):
+        score(name="test", label="pass")
+        span = exporter.get_finished_spans()[0]
+        assert span.attributes["gen_ai.evaluation.score.label"] == "pass"
+
+    def test_no_label(self, exporter):
+        score(name="test", value=0.5)
+        span = exporter.get_finished_spans()[0]
+        assert "gen_ai.evaluation.score.label" not in span.attributes
+
+    def test_explanation(self, exporter):
+        score(name="test", explanation="Correct answer.")
+        span = exporter.get_finished_spans()[0]
+        assert span.attributes["gen_ai.evaluation.explanation"] == "Correct answer."
+
+    def test_explanation_truncated_at_500(self, exporter):
+        score(name="test", explanation="x" * 1000)
+        span = exporter.get_finished_spans()[0]
+        assert len(span.attributes["gen_ai.evaluation.explanation"]) == 500
+
+    def test_no_explanation(self, exporter):
+        score(name="test", value=0.5)
+        span = exporter.get_finished_spans()[0]
+        assert "gen_ai.evaluation.explanation" not in span.attributes
+
+    def test_source_default(self, exporter):
+        score(name="test", value=0.5)
+        span = exporter.get_finished_spans()[0]
+        assert span.attributes["gen_ai.evaluation.source"] == "sdk"
+
+    def test_source_override(self, exporter):
+        score(name="test", value=0.8, source="llm-judge")
+        span = exporter.get_finished_spans()[0]
+        assert span.attributes["gen_ai.evaluation.source"] == "llm-judge"
+
+    def test_response_id(self, exporter):
+        score(name="test", response_id="chatcmpl-abc123")
+        span = exporter.get_finished_spans()[0]
+        assert span.attributes["gen_ai.response.id"] == "chatcmpl-abc123"
+
+    def test_no_response_id(self, exporter):
+        score(name="test", value=0.5)
+        span = exporter.get_finished_spans()[0]
+        assert "gen_ai.response.id" not in span.attributes
+
+    def test_metadata(self, exporter):
+        score(name="test", value=0.5, metadata={"model": "gpt-4", "temperature": 0.7})
+        span = exporter.get_finished_spans()[0]
+        assert span.attributes["gen_ai.evaluation.metadata.model"] == "gpt-4"
+        assert span.attributes["gen_ai.evaluation.metadata.temperature"] == "0.7"
+
+    def test_no_metadata(self, exporter):
+        score(name="test", value=0.5)
+        span = exporter.get_finished_spans()[0]
+        meta_keys = [k for k in span.attributes if k.startswith("gen_ai.evaluation.metadata.")]
+        assert meta_keys == []
+
+
+# ---------------------------------------------------------------------------
+# Multiple scores
+# ---------------------------------------------------------------------------
+
+
+class TestMultipleScores:
+    def test_multiple_scores_are_independent(self, exporter):
+        score(name="a", value=0.1)
+        score(name="b", value=0.2)
+        score(name="c", value=0.3)
+
+        spans = exporter.get_finished_spans()
+        assert len(spans) == 3
+        values = {
+            s.attributes["gen_ai.evaluation.name"]: s.attributes["gen_ai.evaluation.score.value"]
+            for s in spans
+        }
+        assert values == {"a": 0.1, "b": 0.2, "c": 0.3}
+
+
+# ---------------------------------------------------------------------------
+# _parse_hex helper
+# ---------------------------------------------------------------------------
+
+
+class TestParseHex:
+    def test_plain_hex(self):
+        assert _parse_hex("ff") == 255
+
+    def test_0x_prefix(self):
+        assert _parse_hex("0xff") == 255
+
+    def test_uppercase_0x_prefix(self):
+        assert _parse_hex("0XFF") == 255
+
+    def test_invalid_returns_none(self):
+        assert _parse_hex("not-hex!") is None
+
+    def test_empty_string_returns_zero(self):
+        assert _parse_hex("") == 0


### PR DESCRIPTION
## Description

This PR brings in the full OpenSearch GenAI Observability SDK codebase into the new [opensearch-project/genai-observability-sdk-py](https://github.com/opensearch-project/genai-observability-sdk-py) repository.

## What's included

**Core SDK** (`src/opensearch_genai_observability_sdk_py/`)
- `register()` — one-line OTEL pipeline setup (TracerProvider, exporter, auto-instrumentation). AWS-specific auth params removed — users pass `AWSSigV4OTLPExporter` via `exporter=` for clean vendor separation
- `@workflow`, `@task`, `@agent`, `@tool` decorators — wrap functions as OTEL spans with GenAI semantic convention attributes
- `score()` — emit evaluation metrics as OTEL spans at span, trace, or session level
- `AWSSigV4OTLPExporter` — signs OTLP HTTP requests with AWS SigV4 over the real protobuf body (not empty body). `botocore` is a core dependency
- HTTP and gRPC OTLP exporter support

**Tests** (`tests/`)
- Full test suite covering decorators, exporters, register, and scoring
- Exporter tests verify our wiring (header presence, body forwarding, init guards) — botocore correctness is trusted, not re-tested

**CI/CD** (`.github/workflows/`)
- `ci.yml` — lint, type-check, security scan, and test across Python 3.10–3.13 on every push
- `pr-validation.yml` — conventional commit and DCO enforcement
- `release.yml` — tag-driven PyPI publishing with manual CODEOWNER approval gate before publish

**Docs & Examples**
- README, CONTRIBUTING, CHANGELOG, SECURITY
- `examples/` — tracing basics, scoring, AWS SigV4, async, OpenAI auto-instrumentation

## PyPI
Published as `opensearch-genai-observability-sdk-py`. Version `0.2.6a1` (alpha). `botocore` is a default dependency so `AWSSigV4OTLPExporter` works without any extras flag.

Install:
```bash
pip install --pre opensearch-genai-observability-sdk-py
pip install --pre opensearch-genai-observability-sdk-py[openai]
pip install --pre opensearch-genai-observability-sdk-py[otel-instrumentors]
```

## Files to review
- [decorators.py](https://github.com/opensearch-project/genai-observability-sdk-py/blob/feat/initial-sdk-code/src/opensearch_genai_observability_sdk_py/decorators.py)
- [register.py](https://github.com/opensearch-project/genai-observability-sdk-py/blob/feat/initial-sdk-code/src/opensearch_genai_observability_sdk_py/register.py)
- [exporters.py](https://github.com/opensearch-project/genai-observability-sdk-py/blob/feat/initial-sdk-code/src/opensearch_genai_observability_sdk_py/exporters.py)
- [score.py](https://github.com/opensearch-project/genai-observability-sdk-py/blob/feat/initial-sdk-code/src/opensearch_genai_observability_sdk_py/score.py)
- [pyproject.toml](https://github.com/opensearch-project/genai-observability-sdk-py/blob/feat/initial-sdk-code/pyproject.toml)
- [release.yml](https://github.com/opensearch-project/genai-observability-sdk-py/blob/feat/initial-sdk-code/.github/workflows/release.yml)

## Related
Closes https://github.com/opensearch-project/.github/issues/453