### PR TITLE
fix: align score() with OTel GenAI semantic conventions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,26 @@
+# Agent Instructions
+
+## Before committing
+
+- Run `ruff format .` to auto-format all files
+- Run `ruff check .` to lint
+- Run `mypy src/opensearch_genai_observability_sdk_py --ignore-missing-imports` for type checking
+- Run `pytest tests/` to verify tests pass
+
+## Code style
+
+- Line length: 100 (configured in pyproject.toml)
+- Formatter: ruff
+- Linter: ruff (rules: E, F, W, I, N, UP, S, B)
+
+## Git
+
+- Always sign off commits: `git commit --signoff`
+- Never push to `upstream` remote (opensearch-project). Only push to `origin` (fork).
+- Keep PRs small and incremental. One logical change per PR.
+
+## Documentation
+
+- When changing public API (function signatures, parameters, exports), cross-check README.md examples still work.
+- Verify any code snippets in README.md reflect current API before submitting PR.
+- When adding new APIs or functionality, include a concise usage example in README.md. No boilerplate or filler.

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ def run(question: str) -> str:
 result = run("What is OpenSearch?")
 
 # 4. Submit scores (after workflow completes)
-score(name="relevance", value=0.95, trace_id="...", source="llm-judge")
+score(name="relevance", value=0.95, trace_id="...")
 ```
 
 This produces the following span tree:
@@ -294,7 +294,6 @@ score(
     trace_id="6ebb9835f43af1552f2cebb9f5165e39",
     span_id="89829115c2128845",
     explanation="Weather data matches ground truth",
-    source="heuristic",
 )
 
 # Trace-level: score the entire trace (score attaches to the root span)
@@ -303,7 +302,10 @@ score(
     value=0.92,
     trace_id="6ebb9835f43af1552f2cebb9f5165e39",
     explanation="Response addresses the user's query",
-    source="llm-judge",
+    attributes={
+        "test.suite.name": "nightly_eval",
+        "test.case.result.status": "pass",
+    },
 )
 ```
 
@@ -318,8 +320,7 @@ score(
 | `label` | `str` | Human-readable label (`"pass"`, `"relevant"`, `"correct"`) |
 | `explanation` | `str` | Evaluator justification (truncated to 500 chars) |
 | `response_id` | `str` | LLM completion ID for correlation |
-| `source` | `str` | Score origin: `"sdk"`, `"human"`, `"llm-judge"`, `"heuristic"` |
-| `metadata` | `dict` | Arbitrary key-value metadata |
+| `attributes` | `dict` | Additional span attributes (keys used as-is, e.g. `test.*` from [semantic-conventions#3398](https://github.com/open-telemetry/semantic-conventions/issues/3398)) |
 
 Scores follow the OTel GenAI semantic conventions with `gen_ai.evaluation.*` attributes.
 

--- a/src/opensearch_genai_observability_sdk_py/score.py
+++ b/src/opensearch_genai_observability_sdk_py/score.py
@@ -45,14 +45,23 @@ def score(
     label: str | None = None,
     explanation: str | None = None,
     response_id: str | None = None,
-    source: str = "sdk",
-    metadata: dict[str, Any] | None = None,
+    attributes: dict[str, Any] | None = None,
 ) -> None:
     """Submit an evaluation score as an OTel span.
 
     Creates a ``gen_ai.evaluation.*`` span that is attached to the
     evaluated trace, so scores appear in the same trace waterfall as the
     spans they evaluate.
+
+    Attributes follow the OTel GenAI semantic conventions:
+    - ``gen_ai.evaluation.result`` event (merged):
+      ``gen_ai.evaluation.name``, ``gen_ai.evaluation.score.value``,
+      ``gen_ai.evaluation.score.label``, ``gen_ai.evaluation.explanation``,
+      ``gen_ai.response.id``
+    - Experiment tracking (proposed,
+      https://github.com/open-telemetry/semantic-conventions/issues/3398):
+      ``test.suite.run.id``, ``test.suite.name``, ``test.case.id``,
+      ``test.case.result.status``, ``test.suite.run.status``
 
     Two scoring levels:
 
@@ -73,9 +82,9 @@ def score(
         label: Human-readable label (e.g., ``"pass"``, ``"relevant"``).
         explanation: Evaluator justification or rationale (truncated to 500 chars).
         response_id: Completion ID for correlation with a specific LLM response.
-        source: Who created the score — ``"sdk"``, ``"human"``,
-            ``"llm-judge"``, ``"heuristic"``.
-        metadata: Optional arbitrary key-value metadata.
+        attributes: Additional span attributes (e.g., ``test.*`` from
+            https://github.com/open-telemetry/semantic-conventions/issues/3398).
+            Keys are used as-is — no prefix is added.
 
     Examples:
         # Span-level: score a specific span
@@ -85,16 +94,22 @@ def score(
             trace_id="6ebb9835f43af1552f2cebb9f5165e39",
             span_id="89829115c2128845",
             explanation="Weather data is correct",
-            source="heuristic",
         )
 
-        # Trace-level: score the whole trace (attaches to root span)
+        # With experiment tracking
+        # (https://github.com/open-telemetry/semantic-conventions/issues/3398)
         score(
-            name="relevance",
-            value=0.92,
+            name="helpfulness",
+            value=0.83,
             trace_id="6ebb9835f43af1552f2cebb9f5165e39",
+            label="Very helpful",
             explanation="Response addresses the query",
-            source="llm-judge",
+            attributes={
+                "test.suite.run.id": "run_20250312_001",
+                "test.suite.name": "helpfulness_eval",
+                "test.case.id": "case_001",
+                "test.case.result.status": "pass",
+            },
         )
     """
     tracer = trace.get_tracer(_TRACER_NAME)
@@ -102,7 +117,6 @@ def score(
     attrs: dict[str, Any] = {
         "gen_ai.operation.name": "evaluation",
         "gen_ai.evaluation.name": name,
-        "gen_ai.evaluation.source": source,
     }
 
     if value is not None:
@@ -113,9 +127,8 @@ def score(
         attrs["gen_ai.evaluation.explanation"] = explanation[:500]
     if response_id:
         attrs["gen_ai.response.id"] = response_id
-    if metadata:
-        for k, v in metadata.items():
-            attrs[f"gen_ai.evaluation.metadata.{k}"] = str(v)
+    if attributes:
+        attrs.update(attributes)
 
     ctx = _build_parent_context(trace_id, span_id)
 

--- a/tests/test_score.py
+++ b/tests/test_score.py
@@ -157,16 +157,6 @@ class TestScoreAttributes:
         span = exporter.get_finished_spans()[0]
         assert "gen_ai.evaluation.explanation" not in span.attributes
 
-    def test_source_default(self, exporter):
-        score(name="test", value=0.5)
-        span = exporter.get_finished_spans()[0]
-        assert span.attributes["gen_ai.evaluation.source"] == "sdk"
-
-    def test_source_override(self, exporter):
-        score(name="test", value=0.8, source="llm-judge")
-        span = exporter.get_finished_spans()[0]
-        assert span.attributes["gen_ai.evaluation.source"] == "llm-judge"
-
     def test_response_id(self, exporter):
         score(name="test", response_id="chatcmpl-abc123")
         span = exporter.get_finished_spans()[0]
@@ -177,17 +167,23 @@ class TestScoreAttributes:
         span = exporter.get_finished_spans()[0]
         assert "gen_ai.response.id" not in span.attributes
 
-    def test_metadata(self, exporter):
-        score(name="test", value=0.5, metadata={"model": "gpt-4", "temperature": 0.7})
+    def test_attributes_passthrough(self, exporter):
+        score(
+            name="test",
+            value=0.9,
+            attributes={
+                "test.suite.run.id": "run_001",
+                "test.case.id": "case_001",
+            },
+        )
         span = exporter.get_finished_spans()[0]
-        assert span.attributes["gen_ai.evaluation.metadata.model"] == "gpt-4"
-        assert span.attributes["gen_ai.evaluation.metadata.temperature"] == "0.7"
+        assert span.attributes["test.suite.run.id"] == "run_001"
+        assert span.attributes["test.case.id"] == "case_001"
 
-    def test_no_metadata(self, exporter):
+    def test_no_attributes(self, exporter):
         score(name="test", value=0.5)
         span = exporter.get_finished_spans()[0]
-        meta_keys = [k for k in span.attributes if k.startswith("gen_ai.evaluation.metadata.")]
-        assert meta_keys == []
+        assert "test.suite.run.id" not in span.attributes
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Align `score()` span attributes with the [OTel GenAI semantic conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-events/) and the proposed [experiment tracking proposal](https://github.com/open-telemetry/semantic-conventions-genai/issues/79).

## Breaking Changes

- **Removed** `source` parameter — `gen_ai.evaluation.source` is not in the spec
- **Removed** `metadata` parameter — `gen_ai.evaluation.metadata.*` prefix is not in the spec
- **Added** `attributes` parameter — pass-through dict for arbitrary span attributes (keys used as-is, no prefix added)

## Note on `gen_ai.operation.name: "evaluation"`

We **retain** `gen_ai.operation.name: "evaluation"` even though `evaluation` is not yet a [well-known value](https://opentelemetry.io/docs/specs/semconv/registry/attributes/gen-ai/) for this attribute. The spec allows custom values ("a custom value MAY be used"), and it is the natural complement to the already-merged [`gen_ai.evaluation.result` event](https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-events/). Without it, there is no standard way to identify evaluation spans by operation type. We plan to propose adding `evaluation` to the well-known values upstream via [semantic-conventions#3398](https://github.com/open-telemetry/semantic-conventions-genai/issues/79).

## Attributes Retained (merged spec)

From [`gen_ai.evaluation.result` event](https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-events/):

| Attribute | Requirement Level | Source |
|---|---|---|
| `gen_ai.operation.name` | — | Hardcoded `"evaluation"` (custom value, see note above) |
| `gen_ai.evaluation.name` | Required | `name` param |
| `gen_ai.evaluation.score.value` | Conditionally Required | `value` param |
| `gen_ai.evaluation.score.label` | Conditionally Required | `label` param |
| `gen_ai.evaluation.explanation` | Recommended | `explanation` param |
| `gen_ai.response.id` | Recommended | `response_id` param |

## Experiment Tracking Support

The new `attributes` param enables passing proposed [`test.*` attributes](https://github.com/open-telemetry/semantic-conventions-genai/issues/79) as top-level span attributes:

```python
score(
    name="helpfulness",
    value=0.83,
    trace_id="6ebb9835f43af1552f2cebb9f5165e39",
    label="Very helpful",
    explanation="Response addresses the query",
    attributes={
        "test.suite.run.id": "run_20250312_001",
        "test.suite.name": "helpfulness_eval",
        "test.case.id": "case_001",
        "test.case.result.status": "pass",
    },
)
```

### Verified E2E

Score spans with these attributes indexed correctly in OpenSearch via OTel Collector -> Data Prepper:

```
gen_ai.operation.name:           evaluation
gen_ai.evaluation.name:          helpfulness
gen_ai.evaluation.score.value:   0.833
gen_ai.evaluation.score.label:   Very helpful
gen_ai.evaluation.explanation:   The user asked a straightforward question...
test.suite.run.id:               939199c8-36bd-421a-bb9d-d528a0ca2f47
test.suite.name:                 helpfulness_eval
test.case.id:                    eval-conv_c5d2f8b59e7
test.case.result.status:         pass
```

## Motivation

The previous implementation emitted several non-standard attributes:
- `gen_ai.evaluation.source` — not in any spec or proposal
- `gen_ai.evaluation.metadata.*` — invented prefix, not in any spec or proposal

These would fragment the ecosystem as other tools adopt the standard conventions. This PR ensures we emit only what is in the merged spec and proposed conventions, positioning OpenSearch as a standards-compliant evaluation backend.

## References

- [gen_ai.evaluation.result event spec](https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-events/)
- [GenAI attribute registry](https://opentelemetry.io/docs/specs/semconv/registry/attributes/gen-ai/)
- [Experiment tracking proposal (test.suite.*, test.case.*)](https://github.com/open-telemetry/semantic-conventions-genai/issues/79)
- [gen_ai.operation.name well-known values](https://opentelemetry.io/docs/specs/semconv/registry/attributes/gen-ai/#gen-ai-operation-name)
