### PR TITLE
ci: use softprops/action-gh-release v1 to match launchpad

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -60,7 +60,7 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v1
         with:
           draft: false
           generate_release_notes: true


### PR DESCRIPTION
## Summary
- Downgrade `softprops/action-gh-release` from v2 to v1 to align with the opensearch-launchpad release-drafter workflow

## Test plan
- [ ] Verify release workflow triggers correctly on tag push