### PR TITLE
ci: fix version grep in release-drafter workflow

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -21,7 +21,7 @@ jobs:
       - id: get_data
         run: |
           echo "approvers=$(cat .github/CODEOWNERS | grep @ | tr -d '*\n ' | sed 's/@/,/g' | sed 's/,//1')" >> $GITHUB_OUTPUT
-          VERSION=`cat pyproject.toml | grep "version =" | grep -Eo "[0-9.]+"`
+          VERSION=`cat pyproject.toml | grep "^version =" | grep -Eo "[0-9.]+"`
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Request release approval
@@ -45,7 +45,7 @@ jobs:
           pip install -e ".[dev]"
           pytest tests/ -v
 
-          VERSION=`cat pyproject.toml | grep "version =" | grep -Eo "[0-9.]+"`
+          VERSION=`cat pyproject.toml | grep "^version =" | grep -Eo "[0-9.]+"`
           TAG_VERSION="${GITHUB_REF#refs/tags/}"
           if [ "$TAG_VERSION" != "$VERSION" ]; then
             echo "Version mismatch: tag=$TAG_VERSION, pyproject.toml=$VERSION"


### PR DESCRIPTION
## Summary
- Anchor version grep with `^` to match only `version = "x.y.z"` at the start of a line
- Without the anchor, `grep "version ="` matches 3 lines in pyproject.toml:

| Line | Extracted value |
|------|-----------------|
| `version = "0.2.6"` | `0.2.6` |
| `target-version = "py310"` | `310` |
| `python_version = "3.10"` | `3.10` |

- When written to `$GITHUB_OUTPUT`, the second value `310` is treated as a new entry with invalid format, causing:
```
Error: Unable to process file command 'output' successfully.
Error: Invalid format '310'
```

## Test plan
- Verified locally:
```
# Before (broken)
$ cat pyproject.toml | grep "version =" | grep -Eo "[0-9.]+"
0.2.6
310
3.10

# After (fixed)
$ cat pyproject.toml | grep "^version =" | grep -Eo "[0-9.]+"
0.2.6
```