### PR TITLE
fix: pin urllib3>=2.7.0 and idna>=3.15 to remediate CVEs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,11 @@ dependencies = [
     "opentelemetry-exporter-otlp-proto-http>=1.20.0,<2",
     "opentelemetry-exporter-otlp-proto-grpc>=1.20.0,<2",
     "botocore>=1.29.0",
+    # Transitive pins to force resolvers off vulnerable versions (observability-stack#241):
+    # urllib3 <2.7.0 → CVE-2026-44432 (8.6 high), CVE-2026-44431 (5.9 medium)
+    # idna <3.15 → CVE-2026-45409 (5.3 medium)
+    "urllib3>=2.7.0",
+    "idna>=3.15",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary

Pin `urllib3>=2.7.0` and `idna>=3.15` so resolvers can't pull vulnerable transitive versions through `botocore` and `requests`.

Fixes the alerts surfaced in [opensearch-project/observability-stack#241](https://github.com/opensearch-project/observability-stack/issues/241):

| CVE | Package | Severity | Fix |
| --- | --- | --- | --- |
| [CVE-2026-44432](https://www.mend.io/vulnerability-database/CVE-2026-44432) | urllib3 < 2.7.0 | High (8.6) — Brotli decompression DoS | `urllib3>=2.7.0` |
| [CVE-2026-44431](https://www.mend.io/vulnerability-database/CVE-2026-44431) | urllib3 < 2.7.0 | Medium (5.9) — header leak on cross-origin redirect | `urllib3>=2.7.0` |
| [CVE-2026-45409](https://www.mend.io/vulnerability-database/CVE-2026-45409) | idna < 3.15 | Medium (5.3) — `idna.encode()` DoS on long inputs | `idna>=3.15` |

The 0.2.8 version bump alone didn't change transitive dependency floors, so installs of the SDK still resolved `urllib3==2.6.3` / `idna==3.11`. This change forces safe floors at the SDK level so all downstream consumers inherit the fix.

## Test plan
- [ ] `pip install .` resolves urllib3 ≥ 2.7.0 and idna ≥ 3.15
- [ ] Existing test suite passes
- [ ] Mend rescan on observability-stack no longer reports these CVEs after consumers pick up the new SDK release