### PR TITLE
ci: raise commitlint body-max-line-length to 200

### DIFF
--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -21,6 +21,7 @@
     "subject-case": [2, "never", ["start-case", "pascal-case", "upper-case"]],
     "subject-empty": [2, "never"],
     "subject-full-stop": [2, "never", "."],
-    "header-max-length": [2, "always", 72]
+    "header-max-length": [2, "always", 72],
+    "body-max-line-length": [2, "always", 200]
   }
 }


### PR DESCRIPTION
### Description

The **Validate Conventional Commits** check fails on Dependabot GitHub-Actions bump PRs (e.g. #34). Root cause:

Dependabot's update commits include an auto-generated compare URL in the body:

```
- [Commits](https://github.com/owner/action/compare/<40-char-sha>...<40-char-sha>)
```

Now that all actions are pinned to **full-length (40-char) commit SHAs** per the org policy (#33), this single-URL line is always well over the `body-max-line-length=100` inherited from `@commitlint/config-conventional`, and it cannot be wrapped. Worst case among the actions this repo uses (`amannn/action-semantic-pull-request`) is **159 characters**.

### Fix

Raise `body-max-line-length` to **200**, kept at error severity (`2`).

- Clears the longest possible Dependabot compare URL (159) with headroom.
- Still enforces a sensible cap on human commit bodies — 200 is a reasonable limit, so the rule keeps its value for contributors rather than being disabled.

`header-max-length=72` continues to enforce concise commit subjects.

### Verification
- [x] `.commitlintrc.json` is valid JSON
- [x] Commit signed off (DCO) and conventional-commit format

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.