### PR TITLE
chore: bump version to 0.2.9 for patch release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "opensearch-genai-observability-sdk-py"
-version = "0.2.8"
+version = "0.2.9"
 description = "OpenSearch AI Observability SDK — OTEL-native tracing and scoring for LLM applications"
 authors = [
     { name = "OpenSearch Contributors" },


### PR DESCRIPTION
## Summary

Bumps `version` in `pyproject.toml` from `0.2.8` → `0.2.9` to prepare the next patch release. Per the release workflow (`release-drafter.yml`), a maintainer pushing a matching `0.2.9` tag after this merges will trigger the PyPI publish + GitHub release (gated by the `release-approval` environment).

## Changes since 0.2.8
- fix: pin urllib3>=2.7.0 and idna>=3.15 to remediate CVEs (#31)
- fix: annotate exporter return types to satisfy mypy (#35)
- ci: SHA-pin GitHub Actions; bump checkout→v7.0.0 (#38), gh-release→v3.0.1 (#37), codecov→v7 (#34)
- ci: raise commitlint body-max-line-length to 200 (#36)

## Validation
- `pytest tests/` → 229 passed
- `python -m build` produces `0.2.9` sdist + wheel; wheel imports cleanly

## Release steps after merge
1. Merge this PR.
2. Maintainer tags: `git tag 0.2.9 && git push origin 0.2.9`
3. Approve the `release-approval` environment gate to publish to PyPI + create the GitHub release.